### PR TITLE
Implement support for JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
@@ -54,6 +53,11 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
         super(base, useTimestamp, dtf, null);
     }
 
+    protected DurationSerializer(DurationSerializer base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter dtf) {
+        super(base, useTimestamp, useNanoseconds, dtf, null);
+    }
+
     @Override
     protected DurationSerializer withFormat(Boolean useTimestamp, DateTimeFormatter dtf, JsonFormat.Shape shape) {
         return new DurationSerializer(this, useTimestamp, dtf);
@@ -63,7 +67,7 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
     public void serialize(Duration duration, JsonGenerator generator, SerializerProvider provider) throws IOException
     {
         if (useTimestamp(provider)) {
-            if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            if (useNanoseconds(provider)) {
                 generator.writeNumber(DecimalUtils.toBigDecimal(
                         duration.getSeconds(), duration.getNano()
                 ));
@@ -83,7 +87,7 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
         if (v2 != null) {
             v2.numberType(JsonParser.NumberType.LONG);
             SerializerProvider provider = visitor.getProvider();
-            if ((provider != null) && provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            if ((provider != null) && useNanoseconds(provider)) {
                 // big number, no more specific qualifier to use...
             } else { // otherwise good old Unix timestamp, in milliseconds
                 v2.format(JsonValueFormat.UTC_MILLISEC);
@@ -94,11 +98,16 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
     @Override // since 2.9
     protected JsonToken serializationShape(SerializerProvider provider) {
         if (useTimestamp(provider)) {
-            if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            if (useNanoseconds(provider)) {
                 return JsonToken.VALUE_NUMBER_FLOAT;
             }
             return JsonToken.VALUE_NUMBER_INT;
         }
         return JsonToken.VALUE_STRING;
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new DurationSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializer.java
@@ -42,14 +42,22 @@ public class InstantSerializer extends InstantSerializerBase<Instant>
 
     protected InstantSerializer(InstantSerializer base,
             Boolean useTimestamp, DateTimeFormatter formatter) {
-        super(base, useTimestamp, formatter);
+        this(base, useTimestamp, null, formatter);
+    }
+
+    protected InstantSerializer(InstantSerializer base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter formatter) {
+        super(base, useTimestamp, useNanoseconds, formatter);
     }
 
     @Override
-    protected JSR310FormattedSerializerBase<Instant> withFormat(
-        Boolean useTimestamp,
-        DateTimeFormatter formatter,
-        JsonFormat.Shape shape) {
+    protected JSR310FormattedSerializerBase<Instant> withFormat(Boolean useTimestamp,
+            DateTimeFormatter formatter, JsonFormat.Shape shape) {
         return new InstantSerializer(this, useTimestamp, formatter);
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new InstantSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
@@ -66,7 +65,13 @@ public abstract class InstantSerializerBase<T extends Temporal>
     protected InstantSerializerBase(InstantSerializerBase<T> base,
             Boolean useTimestamp, DateTimeFormatter dtf)
     {
-        super(base, useTimestamp, dtf, null);
+        this(base, useTimestamp, null, dtf);
+    }
+
+    protected InstantSerializerBase(InstantSerializerBase<T> base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter dtf)
+    {
+        super(base, useTimestamp, useNanoseconds, dtf, null);
         defaultFormat = base.defaultFormat;
         getEpochMillis = base.getEpochMillis;
         getEpochSeconds = base.getEpochSeconds;
@@ -82,7 +87,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     public void serialize(T value, JsonGenerator generator, SerializerProvider provider) throws IOException
     {
         if (useTimestamp(provider)) {
-            if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            if (useNanoseconds(provider)) {
                 generator.writeNumber(DecimalUtils.toBigDecimal(
                         getEpochSeconds.applyAsLong(value), getNanoseconds.applyAsInt(value)
                 ));
@@ -109,8 +114,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
         throws JsonMappingException
     {
         SerializerProvider prov = visitor.getProvider();
-        if ((prov != null) && 
-                prov.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+        if ((prov != null) && useNanoseconds(prov)) {
             JsonNumberFormatVisitor v2 = visitor.expectNumberFormat(typeHint);
             if (v2 != null) {
                 v2.numberType(NumberType.BIG_DECIMAL);
@@ -126,7 +130,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     @Override // since 2.9
     protected JsonToken serializationShape(SerializerProvider provider) {
         if (useTimestamp(provider)) {
-            if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            if (useNanoseconds(provider)) {
                 return JsonToken.VALUE_NUMBER_FLOAT;
             }
             return JsonToken.VALUE_NUMBER_INT;

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.WritableTypeId;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 
@@ -49,13 +48,13 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
         super(LocalDateTime.class, f);
     }
 
-    private LocalDateTimeSerializer(LocalDateTimeSerializer base, Boolean useTimestamp, DateTimeFormatter f) {
-        super(base, useTimestamp, f, null);
+    private LocalDateTimeSerializer(LocalDateTimeSerializer base, Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter f) {
+        super(base, useTimestamp, useNanoseconds, f, null);
     }
 
     @Override
     protected JSR310FormattedSerializerBase<LocalDateTime> withFormat(Boolean useTimestamp, DateTimeFormatter f, JsonFormat.Shape shape) {
-        return new LocalDateTimeSerializer(this, useTimestamp, f);
+        return new LocalDateTimeSerializer(this, useTimestamp, _useNanoseconds, f);
     }
 
     protected DateTimeFormatter _defaultFormatter() {
@@ -111,7 +110,7 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
         if ((secs > 0) || (nanos > 0)) {
             g.writeNumber(secs);
             if (nanos > 0) {
-                if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+                if (useNanoseconds(provider)) {
                     g.writeNumber(nanos);
                 } else {
                     g.writeNumber(value.get(ChronoField.MILLI_OF_SECOND));
@@ -123,5 +122,10 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
     @Override // since 2.9
     protected JsonToken serializationShape(SerializerProvider provider) {
         return useTimestamp(provider) ? JsonToken.START_ARRAY : JsonToken.VALUE_STRING;
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new LocalDateTimeSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalTimeSerializer.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.WritableTypeId;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 
@@ -50,7 +49,11 @@ public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime
     }
 
     protected LocalTimeSerializer(LocalTimeSerializer base, Boolean useTimestamp, DateTimeFormatter formatter) {
-        super(base, useTimestamp, formatter, null);
+        this(base, useTimestamp, null, formatter);
+    }
+
+    protected LocalTimeSerializer(LocalTimeSerializer base, Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter formatter) {
+        super(base, useTimestamp, useNanoseconds, formatter, null);
     }
 
     @Override
@@ -110,7 +113,7 @@ public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime
         {
             g.writeNumber(secs);
             if (nanos > 0) {
-                if (provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+                if (useNanoseconds(provider)) {
                     g.writeNumber(nanos);
                 } else {
                     g.writeNumber(value.get(ChronoField.MILLI_OF_SECOND));
@@ -122,5 +125,10 @@ public class LocalTimeSerializer extends JSR310FormattedSerializerBase<LocalTime
     @Override // since 2.9
     protected JsonToken serializationShape(SerializerProvider provider) {
         return useTimestamp(provider) ? JsonToken.START_ARRAY : JsonToken.VALUE_STRING;
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new LocalTimeSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/OffsetDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/OffsetDateTimeSerializer.java
@@ -18,7 +18,12 @@ public class OffsetDateTimeSerializer extends InstantSerializerBase<OffsetDateTi
 
     protected OffsetDateTimeSerializer(OffsetDateTimeSerializer base,
             Boolean useTimestamp, DateTimeFormatter formatter) {
-        super(base, useTimestamp, formatter);
+        this(base, useTimestamp, null, formatter);
+    }
+
+    protected OffsetDateTimeSerializer(OffsetDateTimeSerializer base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter formatter) {
+        super(base, useTimestamp, useNanoseconds, formatter);
     }
 
     @Override
@@ -26,5 +31,10 @@ public class OffsetDateTimeSerializer extends InstantSerializerBase<OffsetDateTi
         DateTimeFormatter formatter, JsonFormat.Shape shape)
     {
         return new OffsetDateTimeSerializer(this, useTimestamp, formatter);
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new OffsetDateTimeSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/OffsetTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/OffsetTimeSerializer.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.WritableTypeId;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 
@@ -47,7 +46,12 @@ public class OffsetTimeSerializer extends JSR310FormattedSerializerBase<OffsetTi
 
     protected OffsetTimeSerializer(OffsetTimeSerializer base,
             Boolean useTimestamp, DateTimeFormatter dtf) {
-        super(base, useTimestamp, dtf, null);
+        this(base, useTimestamp, null, dtf);
+    }
+
+    protected OffsetTimeSerializer(OffsetTimeSerializer base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter dtf) {
+        super(base, useTimestamp, useNanoseconds, dtf, null);
     }
 
     @Override
@@ -94,7 +98,7 @@ public class OffsetTimeSerializer extends JSR310FormattedSerializerBase<OffsetTi
         if ((secs > 0) || (nanos > 0)) {
             g.writeNumber(secs);
             if (nanos > 0) {
-                if(provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+                if(useNanoseconds(provider)) {
                     g.writeNumber(nanos);
                 } else {
                     g.writeNumber(value.get(ChronoField.MILLI_OF_SECOND));
@@ -107,5 +111,10 @@ public class OffsetTimeSerializer extends JSR310FormattedSerializerBase<OffsetTi
     @Override // since 2.9
     protected JsonToken serializationShape(SerializerProvider provider) {
         return useTimestamp(provider) ? JsonToken.START_ARRAY : JsonToken.VALUE_STRING;
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new OffsetTimeSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
@@ -36,7 +36,13 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
 
     protected ZonedDateTimeSerializer(ZonedDateTimeSerializer base,
             Boolean useTimestamp, DateTimeFormatter formatter, Boolean writeZoneId) {
-        super(base, useTimestamp, formatter);
+        this(base, useTimestamp, null, formatter, writeZoneId);
+    }
+
+    protected ZonedDateTimeSerializer(ZonedDateTimeSerializer base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter formatter,
+            Boolean writeZoneId) {
+        super(base, useTimestamp, useNanoseconds, formatter);
         _writeZoneId = writeZoneId;
     }
 
@@ -51,6 +57,11 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     @Override
     protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId) {
         return new ZonedDateTimeSerializer(this, _useTimestamp, _formatter, writeZoneId);
+    }
+
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new ZonedDateTimeSerializer(this, _useTimestamp, writeNanoseconds, _formatter, writeZoneId);
     }
 
     @Override

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeWithZoneIdSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeWithZoneIdSerializer.java
@@ -27,7 +27,12 @@ public class ZonedDateTimeWithZoneIdSerializer extends InstantSerializerBase<Zon
 
     protected ZonedDateTimeWithZoneIdSerializer(ZonedDateTimeWithZoneIdSerializer base,
             Boolean useTimestamp, DateTimeFormatter formatter) {
-        super(base, useTimestamp, formatter);
+        this(base, useTimestamp, null, formatter);
+    }
+
+    protected ZonedDateTimeWithZoneIdSerializer(ZonedDateTimeWithZoneIdSerializer base,
+            Boolean useTimestamp, Boolean useNanoseconds, DateTimeFormatter formatter) {
+        super(base, useTimestamp, useNanoseconds, formatter);
     }
 
     @Override
@@ -37,4 +42,8 @@ public class ZonedDateTimeWithZoneIdSerializer extends InstantSerializerBase<Zon
         return new ZonedDateTimeWithZoneIdSerializer(this, useTimestamp, formatter);
     }
 
+    @Override
+    protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
+        return new ZonedDateTimeWithZoneIdSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
+    }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/WriteNanosecondsTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/WriteNanosecondsTest.java
@@ -1,0 +1,116 @@
+package com.fasterxml.jackson.datatype.jsr310.ser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class WriteNanosecondsTest extends ModuleTestBase {
+    public static final ZoneId UTC = ZoneId.of("UTC");
+    private static ObjectMapper MAPPER = newMapper();
+
+    @Test
+    public void testSerializeDurationWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<Duration> value = new DummyClass<>(Duration.ZERO);
+
+        String json = MAPPER.writeValueAsString(value);
+
+        assertThat(json, containsString("\"nanoseconds\":0.0"));
+        assertThat(json, containsString("\"notNanoseconds\":0"));
+    }
+
+    @Test
+    public void testSerializeInstantWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<Instant> input = new DummyClass<>(Instant.EPOCH);
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertThat(json, containsString("\"nanoseconds\":0.0"));
+        assertThat(json, containsString("\"notNanoseconds\":0"));
+    }
+
+    @Test
+    public void testSerializeLocalDateTimeWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<LocalDateTime> input = new DummyClass<>(
+                // Nanos will only be written if it's non-zero
+                LocalDateTime.of(1970, 1, 1, 0, 0, 0, 1)
+        );
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertThat(json, containsString("\"nanoseconds\":[1970,1,1,0,0,0,1]"));
+        assertThat(json, containsString("\"notNanoseconds\":[1970,1,1,0,0,0,0]"));
+    }
+
+    @Test
+    public void testSerializeLocalTimeWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<LocalTime> input = new DummyClass<>(
+                // Nanos will only be written if it's non-zero
+                LocalTime.of(0, 0, 0, 1)
+        );
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertThat(json, containsString("\"nanoseconds\":[0,0,0,1]"));
+        assertThat(json, containsString("\"notNanoseconds\":[0,0,0,0]"));
+    }
+
+    @Test
+    public void testSerializeOffsetDateTimeWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<OffsetDateTime> input = new DummyClass<>(OffsetDateTime.ofInstant(Instant.EPOCH, UTC));
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertThat(json, containsString("\"nanoseconds\":0.0"));
+        assertThat(json, containsString("\"notNanoseconds\":0"));
+    }
+
+    @Test
+    public void testSerializeOffsetTimeWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<OffsetTime> input = new DummyClass<>(
+                // Nanos will only be written if it's non-zero
+                OffsetTime.of(0,0,0, 1 , ZoneOffset.UTC)
+        );
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertThat(json, containsString("\"nanoseconds\":[0,0,0,1,\"Z\"]"));
+        assertThat(json, containsString("\"notNanoseconds\":[0,0,0,0,\"Z\"]"));
+    }
+
+    @Test
+    public void testSerializeZonedDateTimeWithAndWithoutNanoseconds() throws Exception {
+        DummyClass<ZonedDateTime> input = new DummyClass<>(ZonedDateTime.ofInstant(Instant.EPOCH, UTC));
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertThat(json, containsString("\"nanoseconds\":0.0"));
+        assertThat(json, containsString("\"notNanoseconds\":0"));
+    }
+
+    private static class DummyClass<T> {
+        @JsonFormat(with = JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+        private final T nanoseconds;
+
+        @JsonFormat(without = JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+        private final T notNanoseconds;
+
+        DummyClass(T t) {
+            this.nanoseconds = t;
+            this.notNanoseconds = t;
+        }
+    }
+}


### PR DESCRIPTION
Fixes FasterXML/jackson-datatype-jsr310#98