### PR TITLE
Use `SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS` for configuring `Duration` serialization

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
@@ -63,7 +64,12 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
             Boolean useTimestamp, JsonFormat.Shape shape) {
         return new DurationSerializer(this, dtf, useTimestamp);
     }
-    
+
+    @Override
+    protected SerializationFeature getTimestampsFeature() {
+        return SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS;
+    }
+
     @Override
     public void serialize(Duration duration, JsonGenerator generator,
             SerializerProvider provider) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/JSR310FormattedSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/JSR310FormattedSerializerBase.java
@@ -171,6 +171,10 @@ abstract class JSR310FormattedSerializerBase<T>
         }
     }
 
+    protected SerializationFeature getTimestampsFeature() {
+        return SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+    }
+
     protected boolean useTimestamp(SerializerProvider provider) {
         if (_useTimestamp != null) {
             return _useTimestamp.booleanValue();
@@ -184,7 +188,7 @@ abstract class JSR310FormattedSerializerBase<T>
             }
         }
         // assume that explicit formatter definition implies use of textual format
-        return _formatter == null && provider.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return _formatter == null && provider.isEnabled(getTimestampsFeature());
     }
 
     protected boolean _useTimestampExplicitOnly(SerializerProvider provider) {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationSerialization.java
@@ -92,7 +92,7 @@ public class TestDurationSerialization extends ModuleTestBase
     {
         Duration duration = Duration.ofSeconds(60L, 0);
         String value = WRITER
-                .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .without(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
                 .writeValueAsString(duration);
 
         assertNotNull("The value should not be null.", value);
@@ -104,7 +104,7 @@ public class TestDurationSerialization extends ModuleTestBase
     {
         Duration duration = Duration.ofSeconds(13498L, 8374);
         String value = WRITER
-                .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .without(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
                 .writeValueAsString(duration);
 
         assertNotNull("The value should not be null.", value);
@@ -147,7 +147,7 @@ public class TestDurationSerialization extends ModuleTestBase
     public void testSerializationWithTypeInfo03() throws Exception
     {
         ObjectMapper mapper = newMapperBuilder()
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
                 .addMixIn(TemporalAmount.class, MockObjectConfiguration.class)
                 .build();
         Duration duration = Duration.ofSeconds(13498L, 8374);


### PR DESCRIPTION
The current implementation uses `WRITE_DATES_AS_TIMESTAMPS` and ignores `WRITE_DURATIONS_AS_TIMESTAMPS` totally.

I thought it would be less surprising to use `WRITE_DURATIONS_AS_TIMESTAMPS` for time duration serialization.