### PR TITLE
code to handle FasterXML/jackson-databind/issues/2141

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
@@ -41,10 +40,10 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
 
     public static final DurationDeserializer INSTANCE = new DurationDeserializer();
 
-    private static final BigDecimal INSTANT_MAX = new BigDecimal(
-            java.time.Instant.MAX.getEpochSecond() + "." + java.time.Instant.MAX.getNano());
-    private static final BigDecimal INSTANT_MIN = new BigDecimal(
-            java.time.Instant.MIN.getEpochSecond() + "." + java.time.Instant.MIN.getNano());
+    private static final BigDecimal DURATION_MAX = new BigDecimal(
+            Long.MAX_VALUE + "." + java.time.Instant.MAX.getNano());
+    private static final BigDecimal DURATION_MIN = new BigDecimal(
+            Long.MIN_VALUE + "." + java.time.Instant.MIN.getNano());
 
     private DurationDeserializer()
     {
@@ -58,11 +57,11 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
         {
             case JsonTokenId.ID_NUMBER_FLOAT:
                 BigDecimal value = parser.getDecimalValue();
-                // If the decimal isnt within the bounds of a float, bail out
-                if(value.compareTo(INSTANT_MAX) > 0 ||
-                        value.compareTo(INSTANT_MIN) < 0) {
-                    throw new JsonParseException(context.getParser(),
-                            "Value of Float too large to be converted to Duration");
+                // If the decimal isn't within the bounds of a duration, bail out
+                if(value.compareTo(DURATION_MAX) > 0 ||
+                        value.compareTo(DURATION_MIN) < 0) {
+                    throw new DateTimeException(
+                            "Instant exceeds minimum or maximum Duration");
                 }
 
                 long seconds = value.longValue();

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -17,6 +17,7 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
@@ -29,6 +30,8 @@ import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -51,6 +54,11 @@ public class InstantDeserializer<T extends Temporal>
     extends JSR310DateTimeDeserializerBase<T>
 {
     private static final long serialVersionUID = 1L;
+
+    private static final BigDecimal INSTANT_MAX = new BigDecimal(
+            java.time.Instant.MAX.getEpochSecond() + "." + java.time.Instant.MAX.getNano());
+    private static final BigDecimal INSTANT_MIN = new BigDecimal(
+            java.time.Instant.MIN.getEpochSecond() + "." + java.time.Instant.MIN.getNano());
 
     /**
      * Constants used to check if the time offset is zero. See [jackson-modules-java8#18]
@@ -277,8 +285,15 @@ public class InstantDeserializer<T extends Temporal>
                 timestamp, this.getZone(context)));
     }
     
-    protected T _fromDecimal(DeserializationContext context, BigDecimal value)
+    protected T _fromDecimal(DeserializationContext context, BigDecimal value) throws JsonParseException
     {
+        // If the decimal isnt within the bounds of an Instant, bail out
+        if(value.compareTo(INSTANT_MAX) > 0 ||
+                value.compareTo(INSTANT_MIN) < 0) {
+            throw new JsonParseException(context.getParser(),
+                    "Value of String too large to be converted to Instant");
+        }
+
         long seconds = value.longValue();
         int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
         return fromNanoseconds.apply(new FromDecimalArguments(

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -285,13 +285,13 @@ public class InstantDeserializer<T extends Temporal>
                 timestamp, this.getZone(context)));
     }
     
-    protected T _fromDecimal(DeserializationContext context, BigDecimal value) throws JsonParseException
+    protected T _fromDecimal(DeserializationContext context, BigDecimal value)
     {
         // If the decimal isnt within the bounds of an Instant, bail out
         if(value.compareTo(INSTANT_MAX) > 0 ||
                 value.compareTo(INSTANT_MIN) < 0) {
-            throw new JsonParseException(context.getParser(),
-                    "Value of String too large to be converted to Instant");
+            throw new DateTimeException(
+                    "Instant exceeds minimum or maximum instant");
         }
 
         long seconds = value.longValue();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
@@ -1,9 +1,10 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import java.math.BigInteger;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -53,19 +54,6 @@ public class TestDurationDeserialization extends ModuleTestBase
         assertEquals("The value is not correct.", Duration.ofSeconds(13498L, 8374), value);
     }
 
-    /**
-     * This test can potentially hang the VM, so exit if it doesn't finish
-     * within a few seconds.
-     * @throws Exception
-     */
-    @Test(timeout=3000, expected = JsonParseException.class)
-    public void testDeserializationAsFloatWhereStringTooLarge() throws Exception
-    {
-        String customDuration = "1000000000e1000000000";
-        READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
-                .readValue(customDuration);
-    }
-
     @Test
     public void testDeserializationAsFloat04() throws Exception
     {
@@ -73,6 +61,27 @@ public class TestDurationDeserialization extends ModuleTestBase
                 .readValue("13498.000008374");
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", Duration.ofSeconds(13498L, 8374), value);
+    }
+
+    @Test(expected = DateTimeException.class)
+    public void testDeserializationAsFloat05() throws Exception
+    {
+        String customInstant = new BigInteger(Long.toString(Long.MAX_VALUE)).add(BigInteger.ONE) + ".0";
+        READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .readValue(customInstant);
+    }
+
+    /**
+     * This test can potentially hang the VM, so exit if it doesn't finish
+     * within a few seconds.
+     * @throws Exception
+     */
+    @Test(timeout=3000, expected = DateTimeException.class)
+    public void testDeserializationAsFloatWhereStringTooLarge() throws Exception
+    {
+        String customDuration = "1000000000e1000000000";
+        READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .readValue(customDuration);
     }
 
     @Test

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.jsr310;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -50,6 +51,19 @@ public class TestDurationDeserialization extends ModuleTestBase
                 .readValue("13498.000008374");
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", Duration.ofSeconds(13498L, 8374), value);
+    }
+
+    /**
+     * This test can potentially hang the VM, so exit if it doesn't finish
+     * within a few seconds.
+     * @throws Exception
+     */
+    @Test(timeout=3000, expected = JsonParseException.class)
+    public void testDeserializationAsFloatWhereStringTooLarge() throws Exception
+    {
+        String customDuration = "1000000000e1000000000";
+        READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .readValue(customDuration);
     }
 
     @Test

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantSerialization.java
@@ -23,11 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
@@ -418,7 +414,7 @@ public class TestInstantSerialization extends ModuleTestBase
      *
      * @throws Exception
      */
-    @Test(timeout=3000, expected = JsonParseException.class)
+    @Test(timeout=3000, expected = DateTimeException.class)
     public void testDeserializationWithTypeInfoAndStringTooLarge02() throws Exception
     {
         Instant date = Instant.MAX;

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantSerialization.java
@@ -429,8 +429,25 @@ public class TestInstantSerialization extends ModuleTestBase
         m.readValue(
                 "[\"" + Instant.class.getName() + "\","+customInstant+"]", Temporal.class
         );
+        System.out.println("test");
     }
 
+    /**
+     * This test can potentially hang the VM, so exit if it doesn't finish
+     * within a few seconds.
+     *
+     * @throws Exception
+     */
+    @Test(timeout=13000, expected = JsonParseException.class)
+    public void testDeserializationWithTypeInfoAndStringTooFractional01() throws Exception
+    {
+        String customInstant = "1e-100000000000";
+        ObjectMapper m = newMapper()
+                .addMixIn(Temporal.class, MockObjectConfiguration.class);
+        m.readValue(
+                "[\"" + Instant.class.getName() + "\","+customInstant+"]", Temporal.class
+        );
+    }
 
     @Test
     public void testCustomPatternWithAnnotations01() throws Exception


### PR DESCRIPTION
Guards against numbers causing CPU or OOM issues when deserializing
large numbers into Instant or Duration (see https://github.com/FasterXML/jackson-databind/issues/2141
)  by either:

* Scientific notation too large (eg 10000e100000)
* Raw string repesenting a number of length too long

