### PR TITLE
Test behavior of reading Instant and Duration from float.

### DIFF
--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import java.math.BigInteger;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 
@@ -60,6 +61,130 @@ public class TestDurationDeserialization extends ModuleTestBase
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", Duration.ofSeconds(13498L, 8374), value);
     }
+
+    /**
+     * Test the upper-bound of Duration.
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase01() throws Exception
+    {
+        String input = Long.MAX_VALUE + ".999999999";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MAX_VALUE, value.getSeconds());
+        assertEquals(999999999, value.getNano());
+    }
+
+    /**
+     * Test the lower-bound of Duration.
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase02() throws Exception
+    {
+        String input = Long.MIN_VALUE + ".0";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MIN_VALUE, value.getSeconds());
+        assertEquals(0, value.getNano());
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void testDeserializationAsFloatEdgeCase03() throws Exception
+    {
+        // Duration can't go this low
+        READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(Long.MIN_VALUE + ".1");
+    }
+
+    /*
+     * DurationDeserializer currently uses BigDecimal.longValue() which has surprising behavior
+     * for numbers outside the range of Long.  Numbers less than 1e64 will result in the lower 64 bits.
+     * Numbers at or above 1e64 will always result in zero.
+     */
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase04() throws Exception
+    {
+        // Just beyond the upper-bound of Duration.
+        String input = new BigInteger(Long.toString(Long.MAX_VALUE)).add(BigInteger.ONE) + ".0";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MIN_VALUE, value.getSeconds());  // We've turned a positive number into negative duration!
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase05() throws Exception
+    {
+        // Just beyond the lower-bound of Duration.
+        String input = new BigInteger(Long.toString(Long.MIN_VALUE)).subtract(BigInteger.ONE) + ".0";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MAX_VALUE, value.getSeconds());  // We've turned a negative number into positive duration!
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase06() throws Exception
+    {
+        // Into the positive zone where everything becomes zero.
+        String input = "1e64";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase07() throws Exception
+    {
+        // Into the negative zone where everything becomes zero.
+        String input = "-1e64";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    /**
+     * Numbers with very large exponents can take a long time, but still result in zero.
+     * https://github.com/FasterXML/jackson-databind/issues/2141
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase08() throws Exception
+    {
+        String input = "1e10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase09() throws Exception
+    {
+        String input = "-1e10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    /**
+     * Same for large negative exponents.
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase10() throws Exception
+    {
+        String input = "1e-10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase11() throws Exception
+    {
+        String input = "-1e-10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
 
     @Test
     public void testDeserializationAsInt01() throws Exception


### PR DESCRIPTION
This is to document the current behavior of those conversions.

This is in response to issues identified in #84 so as to prevent that fix from altering current behavior.