### PR TITLE
Prevent unbounded latency converting decimals to time

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
@@ -52,9 +52,7 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
         {
             case JsonTokenId.ID_NUMBER_FLOAT:
                 BigDecimal value = parser.getDecimalValue();
-                long seconds = value.longValue();
-                int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
-                return Duration.ofSeconds(seconds, nanoseconds);
+                return DecimalUtils.extractSecondsAndNanos(value, Duration::ofSeconds);
 
             case JsonTokenId.ID_NUMBER_INT:
                 if(context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -91,7 +91,7 @@ public class InstantDeserializer<T extends Temporal>
     protected final Function<FromDecimalArguments, T> fromNanoseconds;
 
     protected final Function<TemporalAccessor, T> parsedToValue;
-    
+
     protected final BiFunction<T, ZoneId, T> adjust;
 
     /**
@@ -150,7 +150,7 @@ public class InstantDeserializer<T extends Temporal>
         replaceZeroOffsetAsZ = base.replaceZeroOffsetAsZ;
         _adjustToContextTZOverride = adjustToContextTimezoneOverride;
     }
-    
+
     @Override
     protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
         if (dtf == _formatter) {
@@ -218,7 +218,7 @@ public class InstantDeserializer<T extends Temporal>
                 // 20-Apr-2016, tatu: Related to [databind#1208], can try supporting embedded
                 //    values quite easily
                 return (T) parser.getEmbeddedObject();
-                
+
             case JsonTokenId.ID_START_ARRAY:
             	return _deserializeFromArray(parser, context);
         }
@@ -265,7 +265,7 @@ public class InstantDeserializer<T extends Temporal>
         }
         return commas;
     }
-    
+
     protected T _fromLong(DeserializationContext context, long timestamp)
     {
         if(context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)){
@@ -276,15 +276,14 @@ public class InstantDeserializer<T extends Temporal>
         return fromMilliseconds.apply(new FromIntegerArguments(
                 timestamp, this.getZone(context)));
     }
-    
+
     protected T _fromDecimal(DeserializationContext context, BigDecimal value)
     {
-        long seconds = value.longValue();
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value, seconds);
-        return fromNanoseconds.apply(new FromDecimalArguments(
-                seconds, nanoseconds, getZone(context)));
+        FromDecimalArguments args =
+            DecimalUtils.extractSecondsAndNanos(value, (s, ns) -> new FromDecimalArguments(s, ns, getZone(context)));
+        return fromNanoseconds.apply(args);
     }
-    
+
     private ZoneId getZone(DeserializationContext context)
     {
         // Instants are always in UTC, so don't waste compute cycles

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDecimalUtils.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDecimalUtils.java
@@ -82,4 +82,62 @@ public class TestDecimalUtils extends ModuleTestBase
         checkExtractNanos(19827342231L, 999999999, value);
     }
 
+
+    private void checkExtractSecondsAndNanos(long expectedSeconds, int expectedNanos, BigDecimal decimal)
+    {
+        DecimalUtils.extractSecondsAndNanos(decimal, (Long s, Integer ns) -> {
+            assertEquals("The second part is not correct.", expectedSeconds, s.longValue());
+            assertEquals("The nanosecond part is not correct.", expectedNanos, ns.intValue());
+            return null;
+        });
+    }
+
+    @Test
+    public void testExtractSecondsAndNanos01()
+    {
+        BigDecimal value = new BigDecimal("0");
+        checkExtractSecondsAndNanos(0L, 0, value);
+    }
+
+    @Test
+    public void testExtractSecondsAndNanos02()
+    {
+        BigDecimal value = new BigDecimal("15.000000072");
+        checkExtractSecondsAndNanos(15L, 72, value);
+    }
+
+    @Test
+    public void testExtractSecondsAndNanos03()
+    {
+        BigDecimal value = new BigDecimal("15.72");
+        checkExtractSecondsAndNanos(15L, 720000000, value);
+    }
+
+    @Test
+    public void testExtractSecondsAndNanos04()
+    {
+        BigDecimal value = new BigDecimal("19827342231.192837465");
+        checkExtractSecondsAndNanos(19827342231L, 192837465, value);
+    }
+
+    @Test
+    public void testExtractSecondsAndNanos05()
+    {
+        BigDecimal value = new BigDecimal("19827342231");
+        checkExtractSecondsAndNanos(19827342231L, 0, value);
+    }
+
+    @Test
+    public void testExtractSecondsAndNanos06()
+    {
+        BigDecimal value = new BigDecimal("19827342231.999999999");
+        checkExtractSecondsAndNanos(19827342231L, 999999999, value);
+    }
+
+    @Test(timeout = 100)
+    public void testExtractSecondsAndNanos07()
+    {
+        BigDecimal value = new BigDecimal("1e10000000");
+        checkExtractSecondsAndNanos(0L, 0, value);
+    }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDecimalUtils.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDecimalUtils.java
@@ -29,75 +29,57 @@ public class TestDecimalUtils extends ModuleTestBase
                 "19827342231.999888000", decimal);
     }
 
+
+
+    private void checkExtractNanos(long expectedSeconds, int expectedNanos, BigDecimal decimal)
+    {
+        long seconds = decimal.longValue();
+        assertEquals("The second part is not correct.", expectedSeconds, seconds);
+
+        int nanoseconds = DecimalUtils.extractNanosecondDecimal(decimal,  seconds);
+        assertEquals("The nanosecond part is not correct.", expectedNanos, nanoseconds);
+    }
+
     @Test
     public void testExtractNanosecondDecimal01()
     {
         BigDecimal value = new BigDecimal("0");
-
-        long seconds = value.longValue();
-        assertEquals("The second part is not correct.", 0L, seconds);
-
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value,  seconds);
-        assertEquals("The nanosecond part is not correct.", 0, nanoseconds);
+        checkExtractNanos(0L, 0, value);
     }
 
     @Test
     public void testExtractNanosecondDecimal02()
     {
         BigDecimal value = new BigDecimal("15.000000072");
-
-        long seconds = value.longValue();
-        assertEquals("The second part is not correct.", 15L, seconds);
-
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value,  seconds);
-        assertEquals("The nanosecond part is not correct.", 72, nanoseconds);
+        checkExtractNanos(15L, 72, value);
     }
 
     @Test
     public void testExtractNanosecondDecimal03()
     {
         BigDecimal value = new BigDecimal("15.72");
-
-        long seconds = value.longValue();
-        assertEquals("The second part is not correct.", 15L, seconds);
-
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value,  seconds);
-        assertEquals("The nanosecond part is not correct.", 720000000, nanoseconds);
+        checkExtractNanos(15L, 720000000, value);
     }
 
     @Test
     public void testExtractNanosecondDecimal04()
     {
         BigDecimal value = new BigDecimal("19827342231.192837465");
-
-        long seconds = value.longValue();
-        assertEquals("The second part is not correct.", 19827342231L, seconds);
-
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value,  seconds);
-        assertEquals("The nanosecond part is not correct.", 192837465, nanoseconds);
+        checkExtractNanos(19827342231L, 192837465, value);
     }
 
     @Test
     public void testExtractNanosecondDecimal05()
     {
         BigDecimal value = new BigDecimal("19827342231");
-
-        long seconds = value.longValue();
-        assertEquals("The second part is not correct.", 19827342231L, seconds);
-
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value,  seconds);
-        assertEquals("The nanosecond part is not correct.", 0, nanoseconds);
+        checkExtractNanos(19827342231L, 0, value);
     }
 
     @Test
     public void testExtractNanosecondDecimal06()
     {
         BigDecimal value = new BigDecimal("19827342231.999999999");
-
-        long seconds = value.longValue();
-        assertEquals("The second part is not correct.", 19827342231L, seconds);
-
-        int nanoseconds = DecimalUtils.extractNanosecondDecimal(value,  seconds);
-        assertEquals("The nanosecond part is not correct.", 999999999, nanoseconds);
+        checkExtractNanos(19827342231L, 999999999, value);
     }
+
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
@@ -146,7 +146,7 @@ public class TestDurationDeserialization extends ModuleTestBase
      * Numbers with very large exponents can take a long time, but still result in zero.
      * https://github.com/FasterXML/jackson-databind/issues/2141
      */
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase08() throws Exception
     {
         String input = "1e10000000";
@@ -155,7 +155,7 @@ public class TestDurationDeserialization extends ModuleTestBase
         assertEquals(0, value.getSeconds());
     }
 
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase09() throws Exception
     {
         String input = "-1e10000000";
@@ -167,7 +167,7 @@ public class TestDurationDeserialization extends ModuleTestBase
     /**
      * Same for large negative exponents.
      */
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase10() throws Exception
     {
         String input = "1e-10000000";
@@ -176,7 +176,7 @@ public class TestDurationDeserialization extends ModuleTestBase
         assertEquals(0, value.getSeconds());
     }
 
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase11() throws Exception
     {
         String input = "-1e-10000000";

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationDeserialization.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import java.math.BigInteger;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 
@@ -60,6 +61,130 @@ public class TestDurationDeserialization extends ModuleTestBase
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", Duration.ofSeconds(13498L, 8374), value);
     }
+
+    /**
+     * Test the upper-bound of Duration.
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase01() throws Exception
+    {
+        String input = Long.MAX_VALUE + ".999999999";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MAX_VALUE, value.getSeconds());
+        assertEquals(999999999, value.getNano());
+    }
+
+    /**
+     * Test the lower-bound of Duration.
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase02() throws Exception
+    {
+        String input = Long.MIN_VALUE + ".0";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MIN_VALUE, value.getSeconds());
+        assertEquals(0, value.getNano());
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void testDeserializationAsFloatEdgeCase03() throws Exception
+    {
+        // Duration can't go this low
+        READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(Long.MIN_VALUE + ".1");
+    }
+
+    /*
+     * DurationDeserializer currently uses BigDecimal.longValue() which has surprising behavior
+     * for numbers outside the range of Long.  Numbers less than 1e64 will result in the lower 64 bits.
+     * Numbers at or above 1e64 will always result in zero.
+     */
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase04() throws Exception
+    {
+        // Just beyond the upper-bound of Duration.
+        String input = new BigInteger(Long.toString(Long.MAX_VALUE)).add(BigInteger.ONE) + ".0";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MIN_VALUE, value.getSeconds());  // We've turned a positive number into negative duration!
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase05() throws Exception
+    {
+        // Just beyond the lower-bound of Duration.
+        String input = new BigInteger(Long.toString(Long.MIN_VALUE)).subtract(BigInteger.ONE) + ".0";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(Long.MAX_VALUE, value.getSeconds());  // We've turned a negative number into positive duration!
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase06() throws Exception
+    {
+        // Into the positive zone where everything becomes zero.
+        String input = "1e64";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase07() throws Exception
+    {
+        // Into the negative zone where everything becomes zero.
+        String input = "-1e64";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    /**
+     * Numbers with very large exponents can take a long time, but still result in zero.
+     * https://github.com/FasterXML/jackson-databind/issues/2141
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase08() throws Exception
+    {
+        String input = "1e10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase09() throws Exception
+    {
+        String input = "-1e10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    /**
+     * Same for large negative exponents.
+     */
+    @Test
+    public void testDeserializationAsFloatEdgeCase10() throws Exception
+    {
+        String input = "1e-10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
+    @Test
+    public void testDeserializationAsFloatEdgeCase11() throws Exception
+    {
+        String input = "-1e-10000000";
+        Duration value = READER.without(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                 .readValue(input);
+        assertEquals(0, value.getSeconds());
+    }
+
 
     @Test
     public void testDeserializationAsInt01() throws Exception

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestInstantSerialization.java
@@ -311,7 +311,7 @@ public class TestInstantSerialization extends ModuleTestBase
      * Numbers with very large exponents can take a long time, but still result in zero.
      * https://github.com/FasterXML/jackson-databind/issues/2141
      */
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase08() throws Exception
     {
         String input = "1e10000000";
@@ -319,7 +319,7 @@ public class TestInstantSerialization extends ModuleTestBase
         assertEquals(0, value.getEpochSecond());
     }
 
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase09() throws Exception
     {
         String input = "-1e10000000";
@@ -330,7 +330,7 @@ public class TestInstantSerialization extends ModuleTestBase
     /**
      * Same for large negative exponents.
      */
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase10() throws Exception
     {
         String input = "1e-10000000";
@@ -338,7 +338,7 @@ public class TestInstantSerialization extends ModuleTestBase
         assertEquals(0, value.getEpochSecond());
     }
 
-    @Test
+    @Test(timeout = 100)
     public void testDeserializationAsFloatEdgeCase11() throws Exception
     {
         String input = "-1e-10000000";


### PR DESCRIPTION
This change prevents latency explosions when working with high-magnitude `BigDecimal` values, while preserving the current behavior on the edge cases.

It's fixes the original bug reported in https://github.com/FasterXML/jackson-databind/issues/2141 but not the several related issues discussed therein. It builds atop my earlier PR https://github.com/FasterXML/jackson-modules-java8/pull/85

One challenge here is that the current two-step conversion process, using `BigDecimal.longValue()` and `DecimalUtils. extractNanosecondDecimal()` separately, made it hard to control the edge cases because information is lost during the former.  So I combined the two into a single helper method.

(IMO these helpers shouldn't be public API, since they are bespoke semantics needed by this package, and unlikely to be usable by other contexts.  Frankly I'd prefer to make the new helper method package-protected, if that's okay with the maintainers.)