### PR TITLE
Enabled formatting by pattern for java.time.Duration

### DIFF
--- a/datetime/pom.xml
+++ b/datetime/pom.xml
@@ -41,6 +41,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
@@ -21,8 +21,10 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/TestDurationSerialization.java
@@ -1,20 +1,38 @@
 package com.fasterxml.jackson.datatype.jsr310;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class TestDurationSerialization extends ModuleTestBase
 {
     private ObjectWriter WRITER;
+
+    final static class HMSWrapper {
+        @JsonFormat(pattern="HH:mm:ss",
+                shape=JsonFormat.Shape.STRING)
+        public Duration duration;
+
+        public HMSWrapper() { }
+        public HMSWrapper(Duration d) { duration = d; }
+    }
+
+    final static class DaysDurationWrapper {
+        @JsonFormat(pattern="dd' Day(s)'",
+                shape=JsonFormat.Shape.STRING)
+        public Duration duration;
+
+        public DaysDurationWrapper(Duration d) { duration = d; }
+    }
 
     @Before
     public void setUp()
@@ -156,5 +174,29 @@ public class TestDurationSerialization extends ModuleTestBase
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.",
                 "[\"" + Duration.class.getName() + "\",\"" + duration.toString() + "\"]", value);
+    }
+
+    @Test
+    public void testSerializationWithHMSFormat() throws Exception
+    {
+        Duration duration = Duration.ofSeconds(3676L, 0);
+        final HMSWrapper hmsWrapper = new HMSWrapper(duration);
+        String value = WRITER.writeValueAsString(hmsWrapper);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.",
+                "{\"duration\":\"01:01:16\"}", value);
+    }
+
+    @Test
+    public void testSerializationWithDaysFormat() throws Exception
+    {
+        Duration duration = Duration.ofDays(367L);
+        final DaysDurationWrapper daysWrapper = new DaysDurationWrapper(duration);
+        String value = WRITER.writeValueAsString(daysWrapper);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.",
+                "{\"duration\":\"367 Day(s)\"}", value);
     }
 }


### PR DESCRIPTION
Supports days, hours, minutes, seconds and milliseconds (works with `org.apache.commons.lang3.time.DurationFormatUtils` class)