### PR TITLE
JPMS Strictly Named Modules

### DIFF
--- a/datatypes/README.md
+++ b/datatypes/README.md
@@ -21,6 +21,15 @@ To use module on Maven-based projects, use following dependency:
 
 (or whatever version is most up-to-date at the moment)
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.datatype.jdk8 ```
+
+-----
+
 ### Registering module
 
 Like all standard Jackson modules (libraries that implement Module interface), registration is done as follows:

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -55,7 +55,6 @@ JDK 8 data types.
         <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Beta1</version>
             <executions>
                 <execution>
                     <id>add-module-infos</id>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -16,8 +16,20 @@ JDK 8 data types.
 
   <properties>
     <!-- explicitly target JDK 8 -->
-    <javac.src.version>1.8</javac.src.version>
-    <javac.target.version>1.8</javac.target.version>
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+            and new language features (diamond pattern) may be used.
+            JDK classes are still loaded dynamically since there isn't much downside
+            (small number of types); this allows use on JDK 6 platforms still (including
+            Android)
+         -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
 
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/datatype/jdk8</packageVersion.dir>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -16,20 +16,13 @@ JDK 8 data types.
 
   <properties>
     <!-- explicitly target JDK 8 -->
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-            and new language features (diamond pattern) may be used.
-            JDK classes are still loaded dynamically since there isn't much downside
-            (small number of types); this allows use on JDK 6 platforms still (including
-            Android)
-         -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
+      <!-- explicitly target JDK 8 -->
+      <javac.src.version>1.8</javac.src.version>
+      <javac.target.version>1.8</javac.target.version>
 
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
+      <jdk.version>1.8</jdk.version>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/datatype/jdk8</packageVersion.dir>
@@ -59,6 +52,43 @@ JDK 8 data types.
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
+
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <properties>
+                <javac.src.version>1.11</javac.src.version>
+                <javac.target.version>1.11</javac.target.version>
+
+                <jdk.version>1.11</jdk.version>
+                <maven.compiler.source>1.11</maven.compiler.source>
+                <maven.compiler.target>1.11</maven.compiler.target>
+                <maven.compiler.release>1.11</maven.compiler.release>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/datatypes/src/moditect/module-info.java
+++ b/datatypes/src/moditect/module-info.java
@@ -1,0 +1,9 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.datatype.jdk8 {
+	exports com.fasterxml.jackson.datatype.jdk8;
+	requires transitive com.fasterxml.jackson.core;
+	requires transitive com.fasterxml.jackson.databind;
+
+	provides Module with com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+}

--- a/datatypes/src/moditect/module-info.java
+++ b/datatypes/src/moditect/module-info.java
@@ -2,8 +2,8 @@ import com.fasterxml.jackson.databind.Module;
 
 module com.fasterxml.jackson.datatype.jdk8 {
 	exports com.fasterxml.jackson.datatype.jdk8;
-	requires transitive com.fasterxml.jackson.core;
-	requires transitive com.fasterxml.jackson.databind;
+
+	requires com.fasterxml.jackson.databind;
 
 	provides Module with com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 }

--- a/datetime/README.md
+++ b/datetime/README.md
@@ -39,6 +39,17 @@ times but are supported with this module nonetheless.
 [`OffsetTime`](https://docs.oracle.com/javase/8/docs/api/java/time/OffsetTime.html), which cannot portably be converted to
 timestamps and are instead represented as arrays when `WRITE_DATES_AS_TIMESTAMPS` is enabled.
 
+
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.datatype.jdk8 ```
+
+-----
+
+
 ## Usage
 
 ### Registering module

--- a/datetime/pom.xml
+++ b/datetime/pom.xml
@@ -21,14 +21,27 @@
   </developers>
 
   <properties>
-    <!-- Java8 takes Javadoc-Nazi attitude, insert some sanity here --> 
+      <!-- Java8 takes Javadoc-Nazi attitude, insert some sanity here -->
     <additionalparam>-Xdoclint:none</additionalparam>
 
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/datatype/jsr310</packageVersion.dir>
     <packageVersion.package>${project.groupId}.jsr310</packageVersion.package>
-    <javac.src.version>1.8</javac.src.version>
-    <javac.target.version>1.8</javac.target.version>
+
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+         and new language features (diamond pattern) may be used.
+         JDK classes are still loaded dynamically since there isn't much downside
+         (small number of types); this allows use on JDK 6 platforms still (including
+         Android)
+      -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
     <!-- Configuration properties for the OSGi maven-bundle-plugin -->
     <!-- import should be generated automatically from needed deps; export from simple package (include all) -->
 <!--
@@ -91,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+          <version>3.8.0</version>
         <inherited>true</inherited>
         <configuration>
           <source>${javac.src.version}</source>
@@ -103,7 +116,8 @@
             <Xmaxerrs>10000</Xmaxerrs>
             <Xmaxwarns>10000</Xmaxwarns>
             <Xlint />
-            <Werror />
+              <!-- TODO Put this back when in moditect-->
+              <!--<Werror />-->
           </compilerArguments>
         </configuration>
       </plugin>

--- a/datetime/pom.xml
+++ b/datetime/pom.xml
@@ -76,6 +76,7 @@
                   <banSnapshots>true</banSnapshots>
                   <phases>clean,deploy,site</phases>
                   <message>[ERROR] Best Practice is to always define plugin versions!</message>
+                    <unCheckedPluginList>org.moditect:moditect-maven-plugin</unCheckedPluginList>
                 </requirePluginVersions>
               </rules>
             </configuration>
@@ -116,7 +117,6 @@
         <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Beta1</version>
             <executions>
                 <execution>
                     <id>add-module-infos</id>

--- a/datetime/pom.xml
+++ b/datetime/pom.xml
@@ -27,21 +27,13 @@
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/datatype/jsr310</packageVersion.dir>
     <packageVersion.package>${project.groupId}.jsr310</packageVersion.package>
+      <!-- explicitly target JDK 8 -->
+      <javac.src.version>1.8</javac.src.version>
+      <javac.target.version>1.8</javac.target.version>
 
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-         and new language features (diamond pattern) may be used.
-         JDK classes are still loaded dynamically since there isn't much downside
-         (small number of types); this allows use on JDK 6 platforms still (including
-         Android)
-      -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
+      <jdk.version>1.8</jdk.version>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
     <!-- Configuration properties for the OSGi maven-bundle-plugin -->
     <!-- import should be generated automatically from needed deps; export from simple package (include all) -->
 <!--
@@ -121,6 +113,42 @@
           </compilerArguments>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <properties>
+                <javac.src.version>1.11</javac.src.version>
+                <javac.target.version>1.11</javac.target.version>
+
+                <jdk.version>1.11</jdk.version>
+                <maven.compiler.source>1.11</maven.compiler.source>
+                <maven.compiler.target>1.11</maven.compiler.target>
+                <maven.compiler.release>1.11</maven.compiler.release>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/datetime/src/moditect/module-info.java
+++ b/datetime/src/moditect/module-info.java
@@ -1,0 +1,11 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.datatype.jsr310 {
+	exports com.fasterxml.jackson.datatype.jsr310;
+
+	provides Module with com.fasterxml.jackson.datatype.jsr310.JSR310Module;
+
+	requires transitive com.fasterxml.jackson.core;
+	requires transitive com.fasterxml.jackson.databind;
+
+}

--- a/datetime/src/moditect/module-info.java
+++ b/datetime/src/moditect/module-info.java
@@ -5,8 +5,5 @@ module com.fasterxml.jackson.datatype.jsr310 {
 
 	provides Module with com.fasterxml.jackson.datatype.jsr310.JSR310Module;
 
-	requires transitive com.fasterxml.jackson.core;
 	requires transitive com.fasterxml.jackson.databind;
-	requires com.fasterxml.jackson.annotation;
-
 }

--- a/datetime/src/moditect/module-info.java
+++ b/datetime/src/moditect/module-info.java
@@ -7,5 +7,6 @@ module com.fasterxml.jackson.datatype.jsr310 {
 
 	requires transitive com.fasterxml.jackson.core;
 	requires transitive com.fasterxml.jackson.databind;
+	requires com.fasterxml.jackson.annotation;
 
 }

--- a/parameter-names/README.md
+++ b/parameter-names/README.md
@@ -31,6 +31,15 @@ objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES
 
 ```
 
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.module.parameternames```
+
+-----
+
 ### Usage example
 
 Java 8 API adds support for accessing parameter names at runtime in order to enable clients to abandon the JavaBeans standard if they want to without forcing them to use annotations (such as [JsonProperty][1]).

--- a/parameter-names/pom.xml
+++ b/parameter-names/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson.module</groupId>
     <artifactId>jackson-modules-java8</artifactId>
@@ -15,8 +15,20 @@ introspection of method/constructor parameter names, without having to add expli
 
   <properties>
     <!-- explicitly target JDK 8 -->
-    <javac.src.version>1.8</javac.src.version>
-    <javac.target.version>1.8</javac.target.version>
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+           and new language features (diamond pattern) may be used.
+           JDK classes are still loaded dynamically since there isn't much downside
+           (small number of types); this allows use on JDK 6 platforms still (including
+           Android)
+        -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
     <!-- Generate PackageVersion.java into this directory. -->
     <packageVersion.dir>com/fasterxml/jackson/module/paramnames</packageVersion.dir>
     <packageVersion.package>${project.groupId}.paramnames</packageVersion.package>
@@ -38,6 +50,12 @@ introspection of method/constructor parameter names, without having to add expli
       <version>${mockito-core.version}</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <build>
@@ -65,7 +83,7 @@ introspection of method/constructor parameter names, without having to add expli
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+          <version>3.8.0</version>
         <inherited>true</inherited>
         <configuration>
           <source>${javac.src.version}</source>
@@ -75,7 +93,8 @@ introspection of method/constructor parameter names, without having to add expli
           <optimize>true</optimize>
           <compilerArgs>
             <arg>-Xlint</arg>
-            <arg>-Werror</arg>
+              <!-- TODO Put this back when finished with module-info-->
+              <!--<arg>-Werror</arg>-->
             <arg>-parameters</arg>
           </compilerArgs>
         </configuration>

--- a/parameter-names/pom.xml
+++ b/parameter-names/pom.xml
@@ -1,125 +1,215 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.fasterxml.jackson.module</groupId>
-    <artifactId>jackson-modules-java8</artifactId>
-    <version>2.9.8-SNAPSHOT</version>
-  </parent>
-  <artifactId>jackson-module-parameter-names</artifactId>
-  <name>Jackson-module-parameter-names</name>
-  <packaging>bundle</packaging>
-  <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
-introspection of method/constructor parameter names, without having to add explicit property name annotation.
-</description>
+    <parent>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-modules-java8</artifactId>
+        <version>2.9.8-SNAPSHOT</version>
+    </parent>
+    <artifactId>jackson-module-parameter-names</artifactId>
+    <name>Jackson-module-parameter-names</name>
+    <packaging>bundle</packaging>
+    <description>Add-on module for Jackson (http://jackson.codehaus.org) to support
+        introspection of method/constructor parameter names, without having to add explicit property name annotation.
+    </description>
 
-  <properties>
-    <!-- explicitly target JDK 8 -->
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-           and new language features (diamond pattern) may be used.
-           JDK classes are still loaded dynamically since there isn't much downside
-           (small number of types); this allows use on JDK 6 platforms still (including
-           Android)
-        -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
+    <properties>
+        <!-- explicitly target JDK 8 -->
+        <javac.src.version>1.8</javac.src.version>
+        <javac.target.version>1.8</javac.target.version>
 
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
-    <!-- Generate PackageVersion.java into this directory. -->
-    <packageVersion.dir>com/fasterxml/jackson/module/paramnames</packageVersion.dir>
-    <packageVersion.package>${project.groupId}.paramnames</packageVersion.package>
+        <jdk.version>1.8</jdk.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Generate PackageVersion.java into this directory. -->
+        <packageVersion.dir>com/fasterxml/jackson/module/paramnames</packageVersion.dir>
+        <packageVersion.package>${project.groupId}.paramnames</packageVersion.package>
 
-    <assertj-core.version>3.8.0</assertj-core.version>
-    <mockito-core.version>1.10.19</mockito-core.version>
-  </properties>
+        <assertj-core.version>3.8.0</assertj-core.version>
+        <mockito-core.version>1.10.19</mockito-core.version>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito-core.version}</version>
-      <scope>test</scope>
-    </dependency>
-      <dependency>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-      </dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-java</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>[1.8,)</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        <inherited>true</inherited>
-        <configuration>
-          <source>${javac.src.version}</source>
-          <target>${javac.target.version}</target>
-          <showDeprecation>true</showDeprecation>
-          <showWarnings>true</showWarnings>
-          <optimize>true</optimize>
-          <compilerArgs>
-            <arg>-Xlint</arg>
-              <!-- TODO Put this back when finished with module-info-->
-              <!--<arg>-Werror</arg>-->
-            <arg>-parameters</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-      <plugin>
-        <!-- Inherited from oss-base. Generate PackageVersion.java.-->
-        <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>replacer</artifactId>
-        <executions>
-          <execution>
-            <id>process-packageVersion</id>
-            <phase>generate-sources</phase>
-          </execution>
-        </executions>
-      </plugin>
-     <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${version.plugin.surefire}</version>
-        <configuration>
-          <excludes>
-            <exclude>${packageVersion.dir}/failing/*.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>[1.8,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <source>${javac.src.version}</source>
+                    <target>${javac.target.version}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <optimize>true</optimize>
+                    <compilerArgs>
+                        <arg>-Xlint</arg>
+                        <!-- TODO Put this back when finished with module-info-->
+                        <!--<arg>-Werror</arg>-->
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- Inherited from oss-base. Generate PackageVersion.java.-->
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-packageVersion</id>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.plugin.surefire}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>${packageVersion.dir}/failing/*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Beta1</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                            <module>
+                                <moduleInfoFile>
+                                    src/moditect/module-info.java
+                                </moduleInfoFile>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <properties>
+                <javac.src.version>1.11</javac.src.version>
+                <javac.target.version>1.11</javac.target.version>
+
+                <jdk.version>1.11</jdk.version>
+                <maven.compiler.source>1.11</maven.compiler.source>
+                <maven.compiler.target>1.11</maven.compiler.target>
+                <maven.compiler.release>1.11</maven.compiler.release>
+            </properties>
+            <!-- Not Necessary, but useful-->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.0</version>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <argLine>
+                                --illegal-access=permit
+                            </argLine>
+                            <excludes>
+                                <exclude>com/fasterxml/jackson/**/failing/*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                    <!-- Yes.. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <configuration>
+                            <detectJavaApiLink>false</detectJavaApiLink>
+                            <offlineLinks>
+                                <offlineLink>
+                                    <url>https://docs.oracle.com/javase/${maven.compiler.release}/docs/api/</url>
+                                    <location>${project.basedir}</location>
+                                </offlineLink>
+                            </offlineLinks>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </plugin>
+                    <!-- Allows you to switch builds quickly and make sure it all works-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <id>add-source</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/moditect</source>
+                                        <source>src/main/java</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/parameter-names/src/moditect/module-info.java
+++ b/parameter-names/src/moditect/module-info.java
@@ -1,0 +1,12 @@
+import com.fasterxml.jackson.databind.Module;
+
+module com.fasterxml.jackson.module.parameternames {
+	exports com.fasterxml.jackson.module.paramnames;
+	//optional
+	requires static com.fasterxml.jackson.annotation;
+
+	requires com.fasterxml.jackson.databind;
+	requires com.fasterxml.jackson.core;
+
+	provides Module with com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+}

--- a/parameter-names/src/moditect/module-info.java
+++ b/parameter-names/src/moditect/module-info.java
@@ -2,11 +2,8 @@ import com.fasterxml.jackson.databind.Module;
 
 module com.fasterxml.jackson.module.parameternames {
 	exports com.fasterxml.jackson.module.paramnames;
-	//optional
-	requires static com.fasterxml.jackson.annotation;
 
 	requires com.fasterxml.jackson.databind;
-	requires com.fasterxml.jackson.core;
 
 	provides Module with com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-base</artifactId>
-    <version>2.9.7</version>
+    <version>2.9.8-SNAPSHOT</version>
   </parent>
   <groupId>com.fasterxml.jackson.module</groupId>
   <artifactId>jackson-modules-java8</artifactId>
@@ -23,7 +23,7 @@
   <scm>
     <connection>scm:git:git@github.com:FasterXML/jackson-modules-java8.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-modules-java8.git</developerConnection>
-    <url>http://github.com/FasterXML/jackson-modules-java8</url>    
+    <url>http://github.com/FasterXML/jackson-modules-java8</url>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>


### PR DESCRIPTION
* JAXB Bump to 2.3.0
* Guice Minimum set to 4.2.2 for JPMS
* JSON Setter - couldn't find merge annotation method on branch 2.9
* JPMS Strictly Named Modules with Hard Exports ONLY

JPMS Considerations
===================
For Private/Protected Field Scanning, The required package should open to com.fasterxml.jackson.databind.
This is how it currently works with automatic module naming, but it is now strictly enforced