### PR TITLE
#109 Add Instant deserialization with nanoseconds in case with Long type 

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -59,6 +59,8 @@ public class InstantDeserializer<T extends Temporal>
      */
     private static final Pattern ISO8601_UTC_ZERO_OFFSET_SUFFIX_REGEX = Pattern.compile("\\+00:?(00)?$");
 
+    private static final int NANOS_IN_SEC = 1_000_000_000;
+
     public static final InstantDeserializer<Instant> INSTANT = new InstantDeserializer<>(
             Instant.class, DateTimeFormatter.ISO_INSTANT,
             Instant::from,
@@ -266,11 +268,12 @@ public class InstantDeserializer<T extends Temporal>
         return commas;
     }
 
-    protected T _fromLong(DeserializationContext context, long timestamp)
-    {
-        if(context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)){
+    protected T _fromLong(DeserializationContext context, long timestamp) {
+        if (context.isEnabled(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            long seconds = timestamp / NANOS_IN_SEC;
+            int fraction = (int) (timestamp % NANOS_IN_SEC);
             return fromNanoseconds.apply(new FromDecimalArguments(
-                    timestamp, 0, this.getZone(context)
+                    seconds, fraction, this.getZone(context)
             ));
         }
         return fromMilliseconds.apply(new FromIntegerArguments(

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
@@ -1,0 +1,30 @@
+package com.fasterxml.jackson.datatype.jsr310.deser;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+
+public class InstantDeserTest extends ModuleTestBase {
+    private final ObjectMapper MAPPER = newMapper();
+    private final ObjectReader READER = MAPPER.readerFor(Instant.class);
+
+    @Test
+    public void testReadDateTimestampsAsNanosecondsEnabled() throws Throwable {
+        long seconds = 946684800;
+        long nanos = 900_000_000;
+        Instant value = READER
+                .with(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .readValue(String.valueOf(seconds) + String.valueOf(nanos));
+        expect(Instant.ofEpochSecond(seconds, nanos), value);
+    }
+
+    private static void expect(Object exp, Object value) {
+        assertEquals("The value is not correct.", exp, value);
+    }
+}


### PR DESCRIPTION
(to fix #109)

I have added correct deserialization of java.time.Instant class in case when you pass value without dot