### PR TITLE
Year key deser fix

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
@@ -16,6 +16,7 @@ public class YearKeyDeserializer extends Jsr310KeyDeserializer {
     public static final YearKeyDeserializer INSTANCE = new YearKeyDeserializer();
 
     private YearKeyDeserializer() {
+        // singleton
     }
 
     @Override

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/YearKeyDeserializer.java
@@ -15,23 +15,18 @@ public class YearKeyDeserializer extends Jsr310KeyDeserializer {
 
     public static final YearKeyDeserializer INSTANCE = new YearKeyDeserializer();
 
-    /*
-     * formatter copied from Year. There is no way of getting a reference to the formatter it uses.
-     */
-    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
-            .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
-            .toFormatter();
-
     private YearKeyDeserializer() {
-        // singleton
     }
 
     @Override
     protected Year deserialize(String key, DeserializationContext ctxt) throws IOException {
+
         try {
-            return Year.parse(key, FORMATTER);
-        } catch (DateTimeException e) {
-            return _handleDateTimeException(ctxt, Year.class, e, key);
+            return Year.of(Integer.parseInt(key));
+        } catch (NumberFormatException nfe) {
+            return _handleDateTimeException(ctxt, Year.class, new DateTimeException("Number format exception", nfe), key);
+        } catch (DateTimeException dte) {
+            return _handleDateTimeException(ctxt, Year.class, dte, key);
         }
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
@@ -1,15 +1,17 @@
 package com.fasterxml.jackson.datatype.jsr310.key;
 
-import java.time.Year;
-import java.util.Map;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
-
-import org.junit.Assert;
 import org.junit.Test;
+
+import java.time.Year;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class YearAsKeyTest extends ModuleTestBase
 {
@@ -20,13 +22,40 @@ public class YearAsKeyTest extends ModuleTestBase
 
     @Test
     public void testSerialization() throws Exception {
-        Assert.assertEquals("Value is incorrect", mapAsString("3141", "test"),
+        assertEquals("Value is incorrect", mapAsString("3141", "test"),
                 MAPPER.writeValueAsString(asMap(Year.of(3141), "test")));
     }
 
     @Test
     public void testDeserialization() throws Exception {
-        Assert.assertEquals("Value is incorrect", asMap(Year.of(3141), "test"),
+        assertEquals("Value is incorrect", asMap(Year.of(3141), "test"),
                 READER.readValue(mapAsString("3141", "test")));
+    }
+
+    @Test(expected = InvalidFormatException.class)
+    public void deserializeYearKey_notANumber() throws Exception {
+        READER.readValue(mapAsString("10000BC", "test"));
+    }
+
+    @Test(expected = InvalidFormatException.class)
+    public void deserializeYearKey_notAYear() throws Exception {
+        READER.readValue(mapAsString(Integer.toString(Year.MAX_VALUE+1), "test"));
+    }
+
+    @Test
+    public void serializeAndDeserializeYearKeyUnpadded() throws Exception {
+
+        Year year1 = Year.of(1);
+        Float float1 = 1F;
+
+        Map<Year, Float> testMap = Collections.singletonMap(year1, 1F);
+
+        String serialized = MAPPER.writeValueAsString(testMap);
+
+        TypeReference<Map<Year, Float>> yearFloatTypeReference = new TypeReference<Map<Year, Float>>() {};
+
+        Map<Year, Float> deserialized = MAPPER.readValue(serialized, yearFloatTypeReference);
+        Float floatVal = deserialized.get(year1);
+        assertEquals("Value is incorrect", String.valueOf(1F), floatVal.toString());
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
@@ -45,10 +45,11 @@ public class YearAsKeyTest extends ModuleTestBase
     @Test
     public void serializeAndDeserializeYearKeyUnpadded() throws Exception {
         // fix for issue #51 verify we can deserialize an unpadded year e.g. "1"
+        ObjectMapper unpaddedMapper = newMapper();
         Map<Year, Float> testMap = Collections.singletonMap(Year.of(1), 1F);
-        String serialized = MAPPER.writeValueAsString(testMap);
+        String serialized = unpaddedMapper.writeValueAsString(testMap);
         TypeReference<Map<Year, Float>> yearFloatTypeReference = new TypeReference<Map<Year, Float>>() {};
-        Map<Year, Float> deserialized = MAPPER.readValue(serialized, yearFloatTypeReference);
+        Map<Year, Float> deserialized = unpaddedMapper.readValue(serialized, yearFloatTypeReference);
         assertEquals(testMap, deserialized);
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
@@ -45,17 +45,16 @@ public class YearAsKeyTest extends ModuleTestBase
     @Test
     public void serializeAndDeserializeYearKeyUnpadded() throws Exception {
 
+        // from YearKeyDeserializer doesn't work with non-padded year values #51
         Year year1 = Year.of(1);
         Float float1 = 1F;
 
-        Map<Year, Float> testMap = Collections.singletonMap(year1, 1F);
-
+        Map<Year, Float> testMap = Collections.singletonMap(year1, float1);
         String serialized = MAPPER.writeValueAsString(testMap);
-
         TypeReference<Map<Year, Float>> yearFloatTypeReference = new TypeReference<Map<Year, Float>>() {};
 
         Map<Year, Float> deserialized = MAPPER.readValue(serialized, yearFloatTypeReference);
         Float floatVal = deserialized.get(year1);
-        assertEquals("Value is incorrect", String.valueOf(1F), floatVal.toString());
+        assertEquals("Value is incorrect", String.valueOf(float1), floatVal.toString());
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/key/YearAsKeyTest.java
@@ -44,17 +44,11 @@ public class YearAsKeyTest extends ModuleTestBase
 
     @Test
     public void serializeAndDeserializeYearKeyUnpadded() throws Exception {
-
-        // from YearKeyDeserializer doesn't work with non-padded year values #51
-        Year year1 = Year.of(1);
-        Float float1 = 1F;
-
-        Map<Year, Float> testMap = Collections.singletonMap(year1, float1);
+        // fix for issue #51 verify we can deserialize an unpadded year e.g. "1"
+        Map<Year, Float> testMap = Collections.singletonMap(Year.of(1), 1F);
         String serialized = MAPPER.writeValueAsString(testMap);
         TypeReference<Map<Year, Float>> yearFloatTypeReference = new TypeReference<Map<Year, Float>>() {};
-
         Map<Year, Float> deserialized = MAPPER.readValue(serialized, yearFloatTypeReference);
-        Float floatVal = deserialized.get(year1);
-        assertEquals("Value is incorrect", String.valueOf(float1), floatVal.toString());
+        assertEquals(testMap, deserialized);
     }
 }


### PR DESCRIPTION
This is @ sladkoff's proposal to fix YearKeyDeserializer so it can deserialize keys that are not in the format yyyy , i.e. the the year does not need to be padded with zeros ("0001") but could instead be "1". See issue #51 