### PR TITLE
When strict treat empty string as invalid format for LocalDateDeserializer and LocalDateTimeDeserializer

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -79,6 +79,9 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
         if (parser.hasToken(JsonToken.VALUE_STRING)) {
             String string = parser.getText().trim();
             if (string.length() == 0) {
+                if (!isLenient()) {
+                    return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                }
                 return null;
             }
             // as per [datatype-jsr310#37], only check for optional (and, incorrect...) time marker 'T'

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
@@ -52,15 +52,21 @@ public class LocalDateTimeDeserializer
         super(LocalDateTime.class, formatter);
     }
 
+    /**
+     * Since 2.10
+     */
+    protected LocalDateTimeDeserializer(LocalDateTimeDeserializer base, Boolean leniency) {
+        super(base, leniency);
+    }
+
     @Override
     protected LocalDateTimeDeserializer withDateFormat(DateTimeFormatter formatter) {
         return new LocalDateTimeDeserializer(formatter);
     }
 
-    // !!! TODO: lenient vs strict?
     @Override
     protected LocalDateTimeDeserializer withLeniency(Boolean leniency) {
-        return this;
+        return new LocalDateTimeDeserializer(this, leniency);
     }
 
     @Override
@@ -69,6 +75,9 @@ public class LocalDateTimeDeserializer
         if (parser.hasTokenId(JsonTokenId.ID_STRING)) {
             String string = parser.getText().trim();
             if (string.length() == 0) {
+                if (!isLenient()) {
+                    return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                }
                 return null;
             }
 

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
@@ -24,11 +24,14 @@ import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Map;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -46,6 +49,7 @@ public class LocalDateTimeDeserTest
 {
     private final static ObjectMapper MAPPER = newMapper();
     private final static ObjectReader READER = MAPPER.readerFor(LocalDateTime.class);
+    private final TypeReference<Map<String, LocalDateTime>> MAP_TYPE_REF = new TypeReference<Map<String, LocalDateTime>>() { };
 
     /*
     /**********************************************************
@@ -172,6 +176,58 @@ public class LocalDateTimeDeserTest
             verifyException(e, "Cannot deserialize value of type");
             verifyException(e, "from String \"");
         }
+    }
+
+        /*
+    /**********************************************************
+    /* Tests for empty string handling
+     */
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "datetime";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String dateValAsNullStr = null;
+        String dateValAsEmptyStr = "";
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, dateValAsNullStr));
+        Map<String, LocalDateTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        LocalDateTime actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, dateValAsEmptyStr));
+        Map<String, LocalDateTime> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        LocalDateTime actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting",actualDateFromNullStr, actualDateFromEmptyStr);
+    }
+
+    @Test( expected =  MismatchedInputException.class)
+    public void testStrictDeserializFromEmptyString() throws Exception {
+
+        final String key = "datetime";
+        final ObjectMapper mapper = mapperBuilder()
+                .withConfigOverride(LocalDateTime.class,
+                        c -> c.setFormat(JsonFormat.Value.forLeniency(false))
+                )
+                .build();
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        // even with strict, null value should be deserialized without throwing an exception
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, dateValAsNullStr));
+        Map<String, LocalDateTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String dateValAsEmptyStr = "";
+        // TODO: nothing stops us from writing an empty string, maybe there should be a check there too?
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap("date", dateValAsEmptyStr));
+        // with strict, deserializing an empty string is not permitted
+        objectReader.readValue(valueFromEmptyStr);
     }
 
     /*


### PR DESCRIPTION
If 'strict', treat empty string as invalid format, so that LocalDateDeserializer and LocalDateTimeDeserializer report this as an error instead of mapping to null. See issue #114 