### PR TITLE
issue 58 - NUMBER_INT should be specified when deserializing LocalDate as EpochDays

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -160,7 +160,10 @@ public class InstantDeserializer<T extends Temporal>
     protected InstantDeserializer<T> withLeniency(Boolean leniency) {
         return this;
     }
-    
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<T> withShape(JsonFormat.Shape shape) { return this; }
+
     @SuppressWarnings("unchecked")
     @Override
     public T deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
@@ -34,10 +34,17 @@ public abstract class JSR310DateTimeDeserializerBase<T>
      */
     protected final boolean _isLenient;
 
+    /**
+     * Flag that indicates the {@link JsonFormat.Shape} annotation.
+     *
+     */
+    protected final JsonFormat.Shape _shape;
+
     protected JSR310DateTimeDeserializerBase(Class<T> supportedType, DateTimeFormatter f) {
         super(supportedType);
         _formatter = f;
         _isLenient = true;
+        _shape = null;
     }
 
     protected JSR310DateTimeDeserializerBase(JSR310DateTimeDeserializerBase<T> base,
@@ -45,17 +52,28 @@ public abstract class JSR310DateTimeDeserializerBase<T>
         super(base);
         _formatter = f;
         _isLenient = base._isLenient;
+        _shape = base._shape;
     }
 
     protected JSR310DateTimeDeserializerBase(JSR310DateTimeDeserializerBase<T> base,
             Boolean leniency) {
         super(base);
         _formatter = base._formatter;
+        _shape = base._shape;
         _isLenient = !Boolean.FALSE.equals(leniency);
+    }
+
+    protected JSR310DateTimeDeserializerBase(JSR310DateTimeDeserializerBase<T> base,
+                                             JsonFormat.Shape shape) {
+        super(base);
+        _formatter = base._formatter;
+        _shape = shape;
+        _isLenient = base._isLenient;
     }
 
     protected abstract JSR310DateTimeDeserializerBase<T> withDateFormat(DateTimeFormatter dtf);
     protected abstract JSR310DateTimeDeserializerBase<T> withLeniency(Boolean leniency);
+    protected abstract JSR310DateTimeDeserializerBase<T> withShape(JsonFormat.Shape shape);
 
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
@@ -92,6 +110,12 @@ public abstract class JSR310DateTimeDeserializerBase<T>
                     deser = deser.withLeniency(leniency);
                 }
             }
+            //if (format.hasShape()) {
+                JsonFormat.Shape shape = format.getShape();
+                if (shape != null) {
+                    deser = deser.withShape(shape);
+                }
+            //}
             // any use for TimeZone?
         }
         return deser;

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
@@ -65,6 +66,9 @@ public class LocalDateTimeDeserializer
     protected LocalDateTimeDeserializer withLeniency(Boolean leniency) {
         return new LocalDateTimeDeserializer(this, leniency);
     }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<LocalDateTime> withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public LocalDateTime deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
@@ -21,6 +21,7 @@ import java.time.DateTimeException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -55,6 +56,9 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
     protected LocalTimeDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<LocalTime> withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public LocalTime deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserializer.java
@@ -5,6 +5,7 @@ import java.time.DateTimeException;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -31,6 +32,9 @@ public class MonthDayDeserializer extends JSR310DateTimeDeserializerBase<MonthDa
     protected MonthDayDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<MonthDay> withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public MonthDay deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
@@ -22,6 +22,7 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 
@@ -52,6 +53,9 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
     protected OffsetTimeDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<OffsetTime> withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public OffsetTime deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
@@ -16,6 +16,7 @@
 
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -53,6 +54,9 @@ public class YearDeserializer extends JSR310DateTimeDeserializerBase<Year>
     protected YearDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<Year> withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public Year deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
@@ -21,6 +21,7 @@ import java.time.DateTimeException;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -56,6 +57,9 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
     protected YearMonthDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected JSR310DateTimeDeserializerBase<YearMonth> withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public YearMonth deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
@@ -44,7 +44,15 @@ public class LocalDateDeserTest extends ModuleTestBase
         public Wrapper() { }
         public Wrapper(LocalDate v) { value = v; }
     }
-    
+
+    final static class ShapeWrapper {
+        @JsonFormat(shape=JsonFormat.Shape.NUMBER_INT)
+        public LocalDate date;
+
+        public ShapeWrapper() { }
+        public ShapeWrapper(LocalDate v) { date = v; }
+    }
+
     /*
     /**********************************************************
     /* Deserialization from Int array representation
@@ -197,11 +205,27 @@ public class LocalDateDeserTest extends ModuleTestBase
     {
         ObjectMapper mapper = newMapperBuilder()
                 .withConfigOverride(LocalDate.class,
-                        o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER_INT)))
+                        c -> c.setFormat(JsonFormat.Value.forLeniency(false))
+                )
                 .build();
 
+        ShapeWrapper w = mapper.readValue("{\"date\":123}", ShapeWrapper.class);
+        LocalDate localDate = w.date;
+
         assertEquals("The value is not correct.", LocalDate.of(1970, Month.MAY, 04),
-                mapper.readValue("123", LocalDate.class));
+                localDate);
+    }
+
+    @Test(expected = MismatchedInputException.class)
+    public void testStrictDeserializeFromString() throws Exception
+    {
+        ObjectMapper mapper = newMapperBuilder()
+                .withConfigOverride(LocalDate.class,
+                        c -> c.setFormat(JsonFormat.Value.forLeniency(false))
+                )
+                .build();
+
+        mapper.readValue("{\"value\":123}", Wrapper.class);
     }
 
     /*

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
@@ -161,7 +161,7 @@ public class LocalDateDeserTest extends ModuleTestBase
 
     // But with alternate setting, not so
     @Test
-    public void testStricDeserializeFromInt() throws Exception
+    public void testStrictDeserializeFromInt() throws Exception
     {
         ObjectMapper mapper = mapperBuilder()
                 .withConfigOverride(LocalDate.class,
@@ -178,6 +178,30 @@ public class LocalDateDeserTest extends ModuleTestBase
 
         // 17-Aug-2019, tatu: Should possibly test other mechanism too, but for now let's
         //    be content with just one...
+    }
+
+    @Test
+    public void testLenientDeserializeFromNumberInt() throws Exception
+    {
+        ObjectMapper mapper = newMapperBuilder()
+                .withConfigOverride(LocalDate.class,
+                        o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER_INT)))
+                .build();
+
+        assertEquals("The value is not correct.", LocalDate.of(1970, Month.MAY, 04),
+                mapper.readValue("123", LocalDate.class));
+    }
+
+    @Test
+    public void testStrictDeserializeFromNumberInt() throws Exception
+    {
+        ObjectMapper mapper = newMapperBuilder()
+                .withConfigOverride(LocalDate.class,
+                        o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER_INT)))
+                .build();
+
+        assertEquals("The value is not correct.", LocalDate.of(1970, Month.MAY, 04),
+                mapper.readValue("123", LocalDate.class));
     }
 
     /*


### PR DESCRIPTION
fix for issue #58 NUMBER_INT should be specified when deserializing LocalDate as EpochDays (unless lenient)