### PR TITLE
issue 58 - NUMBER_INT should be specified when deserializing LocalDate as EpochDays

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -164,7 +164,10 @@ public class InstantDeserializer<T extends Temporal>
     protected InstantDeserializer<T> withLeniency(Boolean leniency) {
         return this;
     }
-    
+
+    @Override
+    protected InstantDeserializer<T> withShape(JsonFormat.Shape shape) { return this; }
+
     @SuppressWarnings("unchecked")
     @Override
     public T deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
@@ -39,10 +40,24 @@ public abstract class JSR310DateTimeDeserializerBase<T>
      */
     protected final boolean _isLenient;
 
+    /**
+     * Setting that indicates the {@Link JsonFormat.Shape} specified for this deserializer
+     * as a {@link JsonFormat.Shape} annotation on property or class, or due to per-type
+     * "config override", or from global settings:
+     * If Shape is NUMBER_INT, the input value is considered to be epoch days. If not a
+     * NUMBER_INT, and the deserializer was not specified with the leniency setting of true,
+     * then an exception will be thrown.
+     * @see [jackson-modules-java8#58] for more info
+     *
+     * @since 2.11
+     */
+    protected final Shape _shape;
+
     protected JSR310DateTimeDeserializerBase(Class<T> supportedType, DateTimeFormatter f) {
         super(supportedType);
         _formatter = f;
         _isLenient = true;
+        _shape = null;
     }
 
     /**
@@ -53,6 +68,7 @@ public abstract class JSR310DateTimeDeserializerBase<T>
         super(base);
         _formatter = f;
         _isLenient = base._isLenient;
+        _shape = base._shape;
     }
     
     /**
@@ -63,7 +79,20 @@ public abstract class JSR310DateTimeDeserializerBase<T>
         super(base);
         _formatter = base._formatter;
         _isLenient = !Boolean.FALSE.equals(leniency);
+        _shape = base._shape;
     }
+
+    /**
+     * @since 2.11
+     */
+    protected JSR310DateTimeDeserializerBase(JSR310DateTimeDeserializerBase<T> base,
+                                             Shape shape) {
+        super(base);
+        _formatter = base._formatter;
+        _shape = shape;
+        _isLenient = base._isLenient;
+    }
+
 
     protected abstract JSR310DateTimeDeserializerBase<T> withDateFormat(DateTimeFormatter dtf);
 
@@ -71,6 +100,12 @@ public abstract class JSR310DateTimeDeserializerBase<T>
      * @since 2.10
      */
     protected abstract JSR310DateTimeDeserializerBase<T> withLeniency(Boolean leniency);
+
+    /**
+     * @since 2.11
+     */
+    protected abstract JSR310DateTimeDeserializerBase<T> withShape(Shape shape);
+
 
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
@@ -106,6 +141,12 @@ public abstract class JSR310DateTimeDeserializerBase<T>
                 if (leniency != null) {
                     deser = deser.withLeniency(leniency);
                 }
+            }
+            //Issue #58: For LocalDate deserializers we need to configure the formatter with
+            //a shape picked up from JsonFormat annotation, to decide if the value is EpochSeconds
+            JsonFormat.Shape shape = format.getShape();
+            if (shape != null && shape != _shape) {
+                deser = deser.withShape(shape);
             }
             // any use for TimeZone?
         }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -63,6 +64,13 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
         super(base, leniency);
     }
 
+    /**
+     * Since 2.11
+     */
+    protected LocalDateDeserializer(LocalDateDeserializer base, JsonFormat.Shape shape) {
+        super(base, shape);
+    }
+
     @Override
     protected LocalDateDeserializer withDateFormat(DateTimeFormatter dtf) {
         return new LocalDateDeserializer(this, dtf);
@@ -72,6 +80,9 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
     protected LocalDateDeserializer withLeniency(Boolean leniency) {
         return new LocalDateDeserializer(this, leniency);
     }
+
+    @Override
+    protected LocalDateDeserializer withShape(JsonFormat.Shape shape) { return new LocalDateDeserializer(this, shape); }
 
     @Override
     public LocalDate deserialize(JsonParser parser, DeserializationContext context) throws IOException
@@ -136,10 +147,11 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
         }
         // 06-Jan-2018, tatu: Is this actually safe? Do users expect such coercion?
         if (parser.hasToken(JsonToken.VALUE_NUMBER_INT)) {
-            if (!isLenient()) {
-                return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+            // issue 58 - also check for NUMBER_INT, which needs to be specified when serializing.
+            if (_shape == JsonFormat.Shape.NUMBER_INT || isLenient()) {
+                return LocalDate.ofEpochDay(parser.getLongValue());
             }
-            return LocalDate.ofEpochDay(parser.getLongValue());
+            return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
         }
         return _handleUnexpectedToken(context, parser, "Expected array or string.");
     }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
@@ -68,6 +69,9 @@ public class LocalDateTimeDeserializer
     protected LocalDateTimeDeserializer withLeniency(Boolean leniency) {
         return new LocalDateTimeDeserializer(this, leniency);
     }
+
+    @Override
+    protected LocalDateTimeDeserializer withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public LocalDateTime deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
@@ -21,6 +21,7 @@ import java.time.DateTimeException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -57,6 +58,9 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
     protected LocalTimeDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected LocalTimeDeserializer withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public LocalTime deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserializer.java
@@ -5,6 +5,7 @@ import java.time.DateTimeException;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -33,6 +34,9 @@ public class MonthDayDeserializer extends JSR310DateTimeDeserializerBase<MonthDa
     protected MonthDayDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected MonthDayDeserializer withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public MonthDay deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
@@ -22,6 +22,7 @@ import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
 
@@ -54,6 +55,9 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
     protected OffsetTimeDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected OffsetTimeDeserializer withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public OffsetTime deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserializer.java
@@ -16,6 +16,7 @@
 
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -55,6 +56,9 @@ public class YearDeserializer extends JSR310DateTimeDeserializerBase<Year>
     protected YearDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected YearDeserializer withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public Year deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
@@ -21,6 +21,7 @@ import java.time.DateTimeException;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -58,6 +59,9 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
     protected YearMonthDeserializer withLeniency(Boolean leniency) {
         return this;
     }
+
+    @Override
+    protected YearMonthDeserializer withShape(JsonFormat.Shape shape) { return this; }
 
     @Override
     public YearMonth deserialize(JsonParser parser, DeserializationContext context) throws IOException

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
@@ -45,7 +45,15 @@ public class LocalDateDeserTest extends ModuleTestBase
         public Wrapper() { }
         public Wrapper(LocalDate v) { value = v; }
     }
-    
+
+    final static class ShapeWrapper {
+        @JsonFormat(shape=JsonFormat.Shape.NUMBER_INT)
+        public LocalDate date;
+
+        public ShapeWrapper() { }
+        public ShapeWrapper(LocalDate v) { date = v; }
+    }
+
     /*
     /**********************************************************
     /* Deserialization from Int array representation
@@ -341,6 +349,53 @@ public class LocalDateDeserTest extends ModuleTestBase
         }
     }
 
+    /*
+    /**********************************************************************
+    /*
+     * Tests for issue 58 - NUMBER_INT should be specified when deserializing
+     * LocalDate as EpochDays
+     */
+    /**********************************************************************
+    */
+    @Test
+    public void testLenientDeserializeFromNumberInt() throws Exception {
+        ObjectMapper mapper = newMapper();
+        mapper.configOverride(LocalDate.class)
+                        .setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.NUMBER_INT));
+
+        assertEquals("The value is not correct.", LocalDate.of(1970, Month.MAY, 04),
+                mapper.readValue("123", LocalDate.class));
+    }
+
+    @Test
+    public void testStrictDeserializeFromNumberInt() throws Exception
+    {
+        ObjectMapper mapper = newMapper();
+        mapper.configOverride(LocalDate.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        ShapeWrapper w = mapper.readValue("{\"date\":123}", ShapeWrapper.class);
+        LocalDate localDate = w.date;
+
+        assertEquals("The value is not correct.", LocalDate.of(1970, Month.MAY, 04),
+                localDate);
+    }
+
+    @Test(expected = MismatchedInputException.class)
+    public void testStrictDeserializeFromString() throws Exception
+    {
+        ObjectMapper mapper = newMapper();
+        mapper.configOverride(LocalDate.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        mapper.readValue("{\"value\":123}", Wrapper.class);
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods
+    /**********************************************************************
+    */
     private void expectFailure(ObjectReader reader, String json) throws Throwable {
         try {
             reader.readValue(aposToQuotes(json));


### PR DESCRIPTION
Should not parse `LocalDate`s from number (timestamp) unless NUMBER_INT specified in annotation, which must already be specified for serialization. See issue #58 for more detail.