### PR TITLE
Prevent deserialization of "" as `null` for `Duration`, `Instant`, `LocalTime`, `OffsetTime`, `Period`, `ZoneDateTime`, `ZoneId`, `ZoneOffset` and `YearMonth` in "strict" (non-lenient) 

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
@@ -20,7 +20,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 
@@ -28,9 +32,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.Locale;
+
 
 /**
  * Deserializer for Java 8 temporal {@link Duration}s.
@@ -52,7 +54,7 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration> imple
     /**
      * Since 2.11
      */
-    public DurationDeserializer(DurationDeserializer base, Boolean leniency) {
+    protected DurationDeserializer(DurationDeserializer base, Boolean leniency) {
         super(base, leniency);
     }
 

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserializer.java
@@ -16,17 +16,21 @@
 
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
 
 /**
  * Deserializer for Java 8 temporal {@link Duration}s.
@@ -34,7 +38,7 @@ import java.time.Duration;
  * @author Nick Williams
  * @since 2.2.0
  */
-public class DurationDeserializer extends JSR310DeserializerBase<Duration>
+public class DurationDeserializer extends JSR310DeserializerBase<Duration> implements ContextualDeserializer
 {
     private static final long serialVersionUID = 1L;
 
@@ -43,6 +47,18 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
     private DurationDeserializer()
     {
         super(Duration.class);
+    }
+
+    /**
+     * Since 2.11
+     */
+    public DurationDeserializer(DurationDeserializer base, Boolean leniency) {
+        super(base, leniency);
+    }
+
+    @Override
+    protected DurationDeserializer withLeniency(Boolean leniency) {
+        return new DurationDeserializer(this, leniency);
     }
 
     @Override
@@ -63,6 +79,9 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
             case JsonTokenId.ID_STRING:
                 String string = parser.getText().trim();
                 if (string.length() == 0) {
+                    if (!isLenient()) {
+                        return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                    }
                     return null;
                 }
                 try {
@@ -80,5 +99,22 @@ public class DurationDeserializer extends JSR310DeserializerBase<Duration>
         }
         return _handleUnexpectedToken(context, parser, JsonToken.VALUE_STRING,
                 JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT);
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
+                                                BeanProperty property) throws JsonMappingException
+    {
+        JsonFormat.Value format = findFormatOverrides(ctxt, property, handledType());
+        DurationDeserializer deser = this;
+        if (format != null) {
+            if (format.hasLenient()) {
+                Boolean leniency = format.getLenient();
+                if (leniency != null) {
+                    deser = deser.withLeniency(leniency);
+                }
+            }
+        }
+        return deser;
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -186,7 +186,9 @@ public class InstantDeserializer<T extends Temporal>
             {
                 String string = parser.getText().trim();
                 if (string.length() == 0) {
-                    return null;
+                    if (!isLenient()) {
+                        return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                    }
                 }
                 // only check for other parsing modes if we are using default formatter
                 if (_formatter == DateTimeFormatter.ISO_INSTANT ||

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -263,11 +263,11 @@ public class InstantDeserializer<T extends Temporal>
             JsonFormat.Value val = findFormatOverrides(ctxt, property, handledType());
             if (val != null) {
                 deserializer = new InstantDeserializer<>(deserializer, val.getFeature(JsonFormat.Feature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE));
-            }
-            if (val.hasLenient()) {
-                Boolean leniency = val.getLenient();
-                if (leniency != null) {
-                    deserializer = deserializer.withLeniency(leniency);
+                if (val.hasLenient()) {
+                    Boolean leniency = val.getLenient();
+                    if (leniency != null) {
+                        deserializer = deserializer.withLeniency(leniency);
+                    }
                 }
             }
         }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -189,6 +189,7 @@ public class InstantDeserializer<T extends Temporal>
                     if (!isLenient()) {
                         return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
                     }
+                    return null;
                 }
                 // only check for other parsing modes if we are using default formatter
                 if (_formatter == DateTimeFormatter.ISO_INSTANT ||

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.Temporal;
 import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -61,6 +62,16 @@ public abstract class JSR310DateTimeDeserializerBase<T>
     }
 
     /**
+     * @since 2.11
+     */
+    public JSR310DateTimeDeserializerBase(Class<T> supportedType, DateTimeFormatter f, Boolean leniency) {
+        super(supportedType);
+        _formatter = f;
+        _isLenient = !Boolean.FALSE.equals(leniency);
+        _shape = null;
+    }
+
+    /**
      * @since 2.10
      */
     protected JSR310DateTimeDeserializerBase(JSR310DateTimeDeserializerBase<T> base,
@@ -92,7 +103,6 @@ public abstract class JSR310DateTimeDeserializerBase<T>
         _shape = shape;
         _isLenient = base._isLenient;
     }
-
 
     protected abstract JSR310DateTimeDeserializerBase<T> withDateFormat(DateTimeFormatter dtf);
 

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310DateTimeDeserializerBase.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.Temporal;
 import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonFormat;

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
@@ -22,11 +22,15 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 
 /**
@@ -41,6 +45,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
  */
 public class JSR310StringParsableDeserializer
     extends JSR310DeserializerBase<Object>
+        implements ContextualDeserializer
 {
     private static final long serialVersionUID = 1L;
 
@@ -66,6 +71,14 @@ public class JSR310StringParsableDeserializer
         _valueType = valueId;
     }
 
+    /**
+     * Since 2.11
+     */
+    protected JSR310StringParsableDeserializer(JSR310StringParsableDeserializer base, Boolean leniency) {
+        super(base, leniency);
+        _valueType = base._valueType;
+    }
+
     @SuppressWarnings("unchecked")
     protected static <T> JsonDeserializer<T> createDeserializer(Class<T> type, int typeId) {
         return (JsonDeserializer<T>) new JSR310StringParsableDeserializer(type, typeId);
@@ -73,8 +86,12 @@ public class JSR310StringParsableDeserializer
 
     @Override
     protected JSR310StringParsableDeserializer withLeniency(Boolean leniency) {
-        // TODO: implement!
-        return null;
+        if (_isLenient == !Boolean.FALSE.equals(leniency)) {
+            return this;
+        }
+        // TODO: or should this be casting as above in createDeserializer? But then in createContext, we need to
+        // call the withLeniency method in this class. (See if we can follow InstantDeser convention here?)
+        return new JSR310StringParsableDeserializer(this, leniency);
     }
 
     @Override
@@ -83,6 +100,9 @@ public class JSR310StringParsableDeserializer
         if (parser.hasToken(JsonToken.VALUE_STRING)) {
             String string = parser.getText().trim();
             if (string.length() == 0) {
+                if (!isLenient()) {
+                    return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                }
                 return null;
             }
             try {
@@ -123,5 +143,22 @@ public class JSR310StringParsableDeserializer
             return deserialize(parser, context);
         }
         return deserializer.deserializeTypedFromAny(parser, context);
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
+                                                BeanProperty property) throws JsonMappingException
+    {
+        JsonFormat.Value format = findFormatOverrides(ctxt, property, handledType());
+        JSR310StringParsableDeserializer deser = this;
+        if (format != null) {
+            if (format.hasLenient()) {
+                Boolean leniency = format.getLenient();
+                if (leniency != null) {
+                    deser = this.withLeniency(leniency);
+                }
+            }
+        }
+        return deser;
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
@@ -72,6 +72,12 @@ public class JSR310StringParsableDeserializer
     }
 
     @Override
+    protected JSR310StringParsableDeserializer withLeniency(Boolean leniency) {
+        // TODO: implement!
+        return null;
+    }
+
+    @Override
     public Object deserialize(JsonParser parser, DeserializationContext context) throws IOException
     {
         if (parser.hasToken(JsonToken.VALUE_STRING)) {

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserializer.java
@@ -48,15 +48,21 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
         super(LocalTime.class, formatter);
     }
 
+    /**
+     * Since 2.11
+     */
+    protected LocalTimeDeserializer(LocalTimeDeserializer base, Boolean leniency) {
+        super(base, leniency);
+    }
+
     @Override
     protected LocalTimeDeserializer withDateFormat(DateTimeFormatter formatter) {
         return new LocalTimeDeserializer(formatter);
     }
 
-    // !!! TODO: lenient vs strict?
     @Override
     protected LocalTimeDeserializer withLeniency(Boolean leniency) {
-        return this;
+        return new LocalTimeDeserializer(this, leniency);
     }
 
     @Override
@@ -68,6 +74,9 @@ public class LocalTimeDeserializer extends JSR310DateTimeDeserializerBase<LocalT
         if (parser.hasToken(JsonToken.VALUE_STRING)) {
             String string = parser.getText().trim();
             if (string.length() == 0) {
+                if (!isLenient()) {
+                    return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                }
                 return null;
             }
             DateTimeFormatter format = _formatter;

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserializer.java
@@ -45,15 +45,21 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
         super(OffsetTime.class, dtf);
     }
 
+    /**
+     * Since 2.11
+     */
+    protected OffsetTimeDeserializer(OffsetTimeDeserializer base, Boolean leniency) {
+        super(base, leniency);
+    }
+
     @Override
     protected OffsetTimeDeserializer withDateFormat(DateTimeFormatter dtf) {
         return new OffsetTimeDeserializer(dtf);
     }
 
-    // !!! TODO: lenient vs strict?
     @Override
     protected OffsetTimeDeserializer withLeniency(Boolean leniency) {
-        return this;
+        return new OffsetTimeDeserializer(this, leniency);
     }
 
     @Override
@@ -65,6 +71,9 @@ public class OffsetTimeDeserializer extends JSR310DateTimeDeserializerBase<Offse
         if (parser.hasToken(JsonToken.VALUE_STRING)) {
             String string = parser.getText().trim();
             if (string.length() == 0) {
+                if (!isLenient()) {
+                    return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                }
                 return null;
             }
             try {

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserializer.java
@@ -49,15 +49,21 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
         super(YearMonth.class, formatter);
     }
 
+    /**
+     * Since 2.11
+     */
+    protected YearMonthDeserializer(YearMonthDeserializer base, Boolean leniency) {
+        super(base, leniency);
+    }
+
     @Override
     protected YearMonthDeserializer withDateFormat(DateTimeFormatter dtf)  {
         return new YearMonthDeserializer(dtf);
     }
 
-    // !!! TODO: lenient vs strict?
     @Override
     protected YearMonthDeserializer withLeniency(Boolean leniency) {
-        return this;
+        return new YearMonthDeserializer(this, leniency);
     }
 
     @Override
@@ -69,6 +75,9 @@ public class YearMonthDeserializer extends JSR310DateTimeDeserializerBase<YearMo
         if (parser.hasToken(JsonToken.VALUE_STRING)) {
             String string = parser.getText().trim();
             if (string.length() == 0) {
+                if (!isLenient()) {
+                    return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
+                }
                 return null;
             }
             try {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/DurationDeserTest.java
@@ -378,6 +378,12 @@ public class DurationDeserTest extends ModuleTestBase
     	assertNull(value);
     }
 
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
     @Test
     public void testLenientDeserializeFromEmptyString() throws Exception {
 

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
@@ -508,21 +508,18 @@ public class InstantDeserTest extends ModuleTestBase
     @Test ( expected =  MismatchedInputException.class)
     public void testStrictDeserializeFromEmptyString() throws Exception {
 
-        final String key = "duration";
+        final String key = "instant";
         final ObjectMapper mapper = mapperBuilder().build();
-        mapper.configOverride(Duration.class)
+        mapper.configOverride(Instant.class)
                 .setFormat(JsonFormat.Value.forLeniency(false));
 
         final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
-        final String dateValAsNullStr = null;
 
-        // even with strict, null value should be deserialized without throwing an exception
-        String valueFromNullStr = mapper.writeValueAsString(asMap(key, dateValAsNullStr));
-        Map<String, Duration> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, Instant> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
         assertNull(actualMapFromNullStr.get(key));
 
-        String dateValAsEmptyStr = "";
-        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, dateValAsEmptyStr));
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
         objectReader.readValue(valueFromEmptyStr);
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
@@ -1,19 +1,13 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.time.DateTimeException;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
+import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -25,10 +19,14 @@ import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+
 public class InstantDeserTest extends ModuleTestBase
 {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
     private static final String CUSTOM_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    private final TypeReference<Map<String, Instant>> MAP_TYPE_REF = new TypeReference<Map<String, Instant>>() { };
 
     static class Wrapper {
         @JsonFormat(
@@ -478,5 +476,53 @@ public class InstantDeserTest extends ModuleTestBase
         Instant actual = mapper.readValue(json, Instant.class);
 
         assertEquals(givenInstant, actual);
+    }
+
+        /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "duration";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String dateValAsNullStr = null;
+        String dateValAsEmptyStr = "";
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, dateValAsNullStr));
+        Map<String, Duration> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        Duration actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, dateValAsEmptyStr));
+        Map<String, Duration> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        Duration actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting", null, actualDateFromEmptyStr);
+    }
+
+    @Test ( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "duration";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(Duration.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        // even with strict, null value should be deserialized without throwing an exception
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, dateValAsNullStr));
+        Map<String, Duration> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String dateValAsEmptyStr = "";
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, dateValAsEmptyStr));
+        objectReader.readValue(valueFromEmptyStr);
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
@@ -216,7 +216,7 @@ public class LocalDateDeserTest extends ModuleTestBase
     }
 
     @Test( expected =  MismatchedInputException.class)
-    public void testStrictDeserializFromEmptyString() throws Exception {
+    public void testStrictDeserializeFromEmptyString() throws Exception {
 
         final String key = "date";
         final ObjectMapper mapper = mapperBuilder().build();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
@@ -208,7 +208,7 @@ public class LocalDateTimeDeserTest
     }
 
     @Test( expected =  MismatchedInputException.class)
-    public void testStrictDeserializFromEmptyString() throws Exception {
+    public void testStrictDeserializeFromEmptyString() throws Exception {
 
         final String key = "datetime";
         final ObjectMapper mapper = mapperBuilder().build();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserTest.java
@@ -242,7 +242,7 @@ public class LocalTimeDeserTest extends ModuleTestBase
     }
 
     @Test( expected =  MismatchedInputException.class)
-    public void testStrictDeserializFromEmptyString() throws Exception {
+    public void testStrictDeserializeFromEmptyString() throws Exception {
 
         final String key = "localTime";
         final ObjectMapper mapper = mapperBuilder().build();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalTimeDeserTest.java
@@ -17,9 +17,12 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -27,7 +30,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -40,6 +45,7 @@ import org.junit.Test;
 public class LocalTimeDeserTest extends ModuleTestBase
 {
     private ObjectReader reader = newMapper().readerFor(LocalTime.class);
+    private final TypeReference<Map<String, LocalTime>> MAP_TYPE_REF = new TypeReference<Map<String, LocalTime>>() { };
 
     @Test
     public void testDeserializationAsTimestamp01() throws Exception
@@ -209,6 +215,48 @@ public class LocalTimeDeserTest extends ModuleTestBase
         assertEquals("The value is not correct.", time, value);
     }
 
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "localTime";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String dateValAsEmptyStr = "";
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, LocalTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        LocalTime actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, dateValAsEmptyStr));
+        Map<String, LocalTime> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        LocalTime actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting",null, actualDateFromEmptyStr);
+    }
+
+    @Test( expected =  MismatchedInputException.class)
+    public void testStrictDeserializFromEmptyString() throws Exception {
+
+        final String key = "localTime";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(LocalTime.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, LocalTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap("date", ""));
+        objectReader.readValue(valueFromEmptyStr);
+    }
 
     private void expectFailure(String aposJson) throws Throwable {
         try {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserTest.java
@@ -163,7 +163,7 @@ public class MonthDayDeserTest extends ModuleTestBase
      */
 
     @Test( expected =  MismatchedInputException.class)
-    public void testStrictDeserializFromEmptyString() throws Exception {
+    public void testStrictDeserializeFromEmptyString() throws Exception {
 
         final String key = "monthDay";
         final ObjectMapper mapper = mapperBuilder().build();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/MonthDayDeserTest.java
@@ -2,10 +2,12 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
@@ -13,10 +15,12 @@ import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.LocalTime;
 import java.time.Month;
 import java.time.MonthDay;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +31,7 @@ public class MonthDayDeserTest extends ModuleTestBase
 {
     private final ObjectMapper MAPPER = newMapper();
     private final ObjectReader READER = MAPPER.readerFor(MonthDay.class);
+    private final TypeReference<Map<String, MonthDay>> MAP_TYPE_REF = new TypeReference<Map<String, MonthDay>>() { };
 
     static class Wrapper {
         @JsonFormat(pattern="MM/dd")
@@ -149,6 +154,28 @@ public class MonthDayDeserTest extends ModuleTestBase
         // 13-May-2019, tatu: [modules-java#107] not fully implemented so can't yet test
         WrapperAsArray output = MAPPER.readValue(json, WrapperAsArray.class);
         assertEquals(input.value, output.value);
+    }
+
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test( expected =  MismatchedInputException.class)
+    public void testStrictDeserializFromEmptyString() throws Exception {
+
+        final String key = "monthDay";
+        final ObjectMapper mapper = mapperBuilder().build();
+        // leniency has no effect here because MonthDayDeser passes through to Java API MonthDay.parse method...
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, MonthDay> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        objectReader.readValue(valueFromEmptyStr);
     }
 
     private void expectFailure(String aposJson) throws Throwable {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -614,7 +614,7 @@ public class OffsetDateTimeDeserTest
         assertEquals(givenInstant.atOffset(ZoneOffset.UTC), actual);
     }
 
-       /*
+    /*
     /**********************************************************
     /* Tests for empty string handling
     /**********************************************************

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -1,35 +1,34 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
+import java.util.Map;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
 public class OffsetDateTimeDeserTest
     extends ModuleTestBase
 {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-
+    private final TypeReference<Map<String, OffsetDateTime>> MAP_TYPE_REF = new TypeReference<Map<String, OffsetDateTime>>() { };
     private static final ZoneId UTC = ZoneId.of("UTC");
 
     private static final ZoneId Z1 = ZoneId.of("America/Chicago");
@@ -613,6 +612,49 @@ public class OffsetDateTimeDeserTest
         OffsetDateTime actual = mapper.readValue(json, OffsetDateTime.class); // this fails
 
         assertEquals(givenInstant.atOffset(ZoneOffset.UTC), actual);
+    }
+
+       /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "OffsetDateTime";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, OffsetDateTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        OffsetDateTime actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        Map<String, OffsetDateTime> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        OffsetDateTime actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting", null, actualDateFromEmptyStr);
+    }
+
+    @Test ( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "OffsetDateTime";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(OffsetDateTime.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, OffsetDateTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        objectReader.readValue(valueFromEmptyStr);
     }
 
     private static void assertIsEqual(OffsetDateTime expected, OffsetDateTime actual)

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetTimeDeserTest.java
@@ -1,10 +1,13 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
@@ -12,10 +15,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.OffsetTime;
+import java.time.Year;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -25,6 +31,9 @@ import static org.junit.Assert.fail;
 
 public class OffsetTimeDeserTest extends ModuleTestBase
 {
+
+    private final TypeReference<Map<String, OffsetTime>> MAP_TYPE_REF = new TypeReference<Map<String, OffsetTime>>() { };
+
     // for [datatype-jsr310#45]
     static class  Pojo45s {
         public String name;
@@ -235,6 +244,49 @@ public class OffsetTimeDeserTest extends ModuleTestBase
                     DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
             .readValue("[]");
         assertNull(value);
+    }
+
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "OffsetTime";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, OffsetTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        OffsetTime actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        Map<String, OffsetTime> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        OffsetTime actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting", null, actualDateFromEmptyStr);
+    }
+
+    @Test ( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "OffsetTime";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(OffsetTime.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, OffsetTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        objectReader.readValue(valueFromEmptyStr);
     }
 
     private void expectFailure(String json) throws Throwable {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/PeriodDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/PeriodDeserTest.java
@@ -16,22 +16,29 @@
 
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
+import java.time.Instant;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.temporal.TemporalAmount;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+
 public class PeriodDeserTest extends ModuleTestBase
 {
     private final ObjectMapper MAPPER = newMapper();
+    private final TypeReference<Map<String, Period>> MAP_TYPE_REF = new TypeReference<Map<String, Period>>() { };
 
     @Test
     public void testDeserialization01() throws Exception
@@ -64,5 +71,46 @@ public class PeriodDeserTest extends ModuleTestBase
         assertNotNull("The value should not be null.", value);
         assertTrue("The value should be a Period.", value instanceof Period);
         assertEquals("The value is not correct.", period, value);
+    }
+
+       /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "period";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, Period> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        Period actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        Map<String, Period> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        Period actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting",null, actualDateFromEmptyStr);
+    }
+
+    @Test( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "period";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(Period.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, Period> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap("date", ""));
+        objectReader.readValue(valueFromEmptyStr);
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/YearDeserTest.java
@@ -18,16 +18,20 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
 import java.time.Year;
+import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
+import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
@@ -40,6 +44,9 @@ import static org.junit.Assert.fail;
 
 public class YearDeserTest extends ModuleTestBase
 {
+
+    private final TypeReference<Map<String, Year>> MAP_TYPE_REF = new TypeReference<Map<String, Year>>() { };
+
     static class FormattedYear {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "'Y'yyyy")
         public Year value;
@@ -203,7 +210,29 @@ public class YearDeserTest extends ModuleTestBase
         ObjectTest result = MAPPER.readValue(json, ObjectTest.class);
         assertEquals(input, result);
     }
-    
+
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "Year";
+        final ObjectMapper mapper = mapperBuilder().build();
+        // YearDeserializer is always strict as far as empty strings, so lenient/strict has no effect
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, Year> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap("date", ""));
+        objectReader.readValue(valueFromEmptyStr);
+    }
+
     /*
     /**********************************************************
     /* Helper methods

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserTest.java
@@ -1,17 +1,24 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.MonthDay;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,6 +28,7 @@ import static org.junit.Assert.fail;
 public class YearMonthDeserTest extends ModuleTestBase
 {
     private final ObjectReader READER = newMapper().readerFor(YearMonth.class);
+    private final TypeReference<Map<String, YearMonth>> MAP_TYPE_REF = new TypeReference<Map<String, YearMonth>>() { };
 
     @Test
     public void testDeserializationAsString01() throws Exception
@@ -77,6 +85,48 @@ public class YearMonthDeserTest extends ModuleTestBase
     	assertNull(value);
     }
 
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "yearMonth";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String dateValAsEmptyStr = "";
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, YearMonth> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        YearMonth actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, dateValAsEmptyStr));
+        Map<String, YearMonth> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        YearMonth actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting",null, actualDateFromEmptyStr);
+    }
+
+    @Test( expected =  MismatchedInputException.class)
+    public void testStrictDeserializFromEmptyString() throws Exception {
+
+        final String key = "YearMonth";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(YearMonth.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, YearMonth> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap("date", ""));
+        objectReader.readValue(valueFromEmptyStr);
+    }
 
     private void expectFailure(String json) throws Throwable {
         try {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/YearMonthDeserTest.java
@@ -112,7 +112,7 @@ public class YearMonthDeserTest extends ModuleTestBase
     }
 
     @Test( expected =  MismatchedInputException.class)
-    public void testStrictDeserializFromEmptyString() throws Exception {
+    public void testStrictDeserializeFromEmptyString() throws Exception {
 
         final String key = "YearMonth";
         final ObjectMapper mapper = mapperBuilder().build();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneIdDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneIdDeserTest.java
@@ -17,10 +17,17 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
@@ -29,6 +36,7 @@ import org.junit.Test;
 public class ZoneIdDeserTest extends ModuleTestBase
 {
     private ObjectMapper MAPPER = newMapper();
+    private final TypeReference<Map<String, ZoneId>> MAP_TYPE_REF = new TypeReference<Map<String, ZoneId>>() { };
 
     private final ObjectMapper MOCK_OBJECT_MIXIN_MAPPER = mapperBuilder()
             .addMixIn(ZoneId.class, MockObjectConfiguration.class)
@@ -53,5 +61,48 @@ public class ZoneIdDeserTest extends ModuleTestBase
     {
         ZoneId value = MOCK_OBJECT_MIXIN_MAPPER.readValue("[\"" + ZoneId.class.getName() + "\",\"America/Denver\"]", ZoneId.class);
         assertEquals("The value is not correct.", ZoneId.of("America/Denver"), value);
+    }
+
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "zoneId";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, ZoneId> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        ZoneId actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        Map<String, ZoneId> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        ZoneId actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting", null, actualDateFromEmptyStr);
+    }
+
+    @Test ( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "zoneId";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(ZoneId.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, ZoneId> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        objectReader.readValue(valueFromEmptyStr);
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneOffsetDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneOffsetDeserTest.java
@@ -126,7 +126,7 @@ public class ZoneOffsetDeserTest extends ModuleTestBase
         assertNull(value);
     }
 
-        /*
+    /*
     /**********************************************************
     /* Tests for empty string handling
     /**********************************************************

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneOffsetDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneOffsetDeserTest.java
@@ -18,12 +18,15 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,6 +41,7 @@ public class ZoneOffsetDeserTest extends ModuleTestBase
 {
     private final static ObjectMapper MAPPER = newMapper();
     private final static ObjectReader READER = MAPPER.readerFor(ZoneOffset.class);
+    private final TypeReference<Map<String, ZoneOffset>> MAP_TYPE_REF = new TypeReference<Map<String, ZoneOffset>>() { };
 
     @Test
     public void testDeserializationFromString() throws Exception
@@ -121,4 +125,48 @@ public class ZoneOffsetDeserTest extends ModuleTestBase
                .readValue("[]");
         assertNull(value);
     }
+
+        /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "zoneOffset";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, ZoneOffset> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        ZoneId actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        Map<String, ZoneOffset> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        ZoneId actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting", null, actualDateFromEmptyStr);
+    }
+
+    @Test ( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "zoneOffset";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(ZoneOffset.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, ZoneOffset> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        objectReader.readValue(valueFromEmptyStr);
+    }
+
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
@@ -130,7 +130,7 @@ public class ZonedDateTimeDeserTest extends ModuleTestBase
     @Test ( expected =  MismatchedInputException.class)
     public void testStrictDeserializeFromEmptyString() throws Exception {
 
-        final String key = "ZonedDateTime";
+        final String key = "zonedDateTime";
         final ObjectMapper mapper = mapperBuilder().build();
         mapper.configOverride(ZonedDateTime.class)
                 .setFormat(JsonFormat.Value.forLeniency(false));

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
@@ -1,17 +1,23 @@
 package com.fasterxml.jackson.datatype.jsr310.deser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -20,6 +26,7 @@ import static org.junit.Assert.fail;
 public class ZonedDateTimeDeserTest extends ModuleTestBase
 {
     private final ObjectReader READER = newMapper().readerFor(ZonedDateTime.class);
+    private final TypeReference<Map<String, ZonedDateTime>> MAP_TYPE_REF = new TypeReference<Map<String, ZonedDateTime>>() { };
 
     @Test
     public void testDeserializationAsString01() throws Exception
@@ -94,6 +101,49 @@ public class ZonedDateTimeDeserTest extends ModuleTestBase
     			.configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
     			.readerFor(ZonedDateTime.class).readValue(aposToQuotes(json));
     	assertNull(value);
+    }
+
+    /*
+    /**********************************************************
+    /* Tests for empty string handling
+    /**********************************************************
+     */
+
+    @Test
+    public void testLenientDeserializeFromEmptyString() throws Exception {
+
+        String key = "zoneDateTime";
+        ObjectMapper mapper = newMapper();
+        ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, ZonedDateTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        ZonedDateTime actualDateFromNullStr = actualMapFromNullStr.get(key);
+        assertNull(actualDateFromNullStr);
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        Map<String, ZonedDateTime> actualMapFromEmptyStr = objectReader.readValue(valueFromEmptyStr);
+        ZonedDateTime actualDateFromEmptyStr = actualMapFromEmptyStr.get(key);
+        assertEquals("empty string failed to deserialize to null with lenient setting", null, actualDateFromEmptyStr);
+    }
+
+    @Test ( expected =  MismatchedInputException.class)
+    public void testStrictDeserializeFromEmptyString() throws Exception {
+
+        final String key = "ZonedDateTime";
+        final ObjectMapper mapper = mapperBuilder().build();
+        mapper.configOverride(ZonedDateTime.class)
+                .setFormat(JsonFormat.Value.forLeniency(false));
+
+        final ObjectReader objectReader = mapper.readerFor(MAP_TYPE_REF);
+        final String dateValAsNullStr = null;
+
+        String valueFromNullStr = mapper.writeValueAsString(asMap(key, null));
+        Map<String, ZonedDateTime> actualMapFromNullStr = objectReader.readValue(valueFromNullStr);
+        assertNull(actualMapFromNullStr.get(key));
+
+        String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
+        objectReader.readValue(valueFromEmptyStr);
     }
 
     private void expectFailure(String json) throws Throwable {


### PR DESCRIPTION
For the java.time classes Duration, Instant, LocalTime, OffsetDateTime, OffsetTime, Period, ZoneDateTime, ZoneId, ZoneOffset and YearMonth, this fix prevents an empty string from being mapped to null where the "strict" (non-lenient) configuration is set.

See issue #138