### PR TITLE
restore fix for parsing of ZoneId that conflicted with changes for issue 138

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/JSR310StringParsableDeserializer.java
@@ -98,7 +98,7 @@ public class JSR310StringParsableDeserializer
                 if (!isLenient()) {
                     return _failForNotLenient(parser, context, JsonToken.VALUE_STRING);
                 }
-                return null;
+                return _coerceEmptyString(context, false);
             }
             try {
                 switch (_typeSelector) {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneIdDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneIdDeserTest.java
@@ -114,8 +114,7 @@ public class ZoneIdDeserTest extends ModuleTestBase
         objectReader.readValue(valueFromEmptyStr);
     }
 
-    // [module-java8#68]: Was to prevent it but... conflicts with [#138]
-    @Ignore
+    // [module-java8#68]
     @Test
     public void testZoneOffsetDeserFromEmpty() throws Exception
     {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneOffsetDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZoneOffsetDeserTest.java
@@ -182,8 +182,7 @@ public class ZoneOffsetDeserTest extends ModuleTestBase
         objectReader.readValue(valueFromEmptyStr);
     }
 
-    // [module-java8#68]: Was to prevent it but... conflicts with [#138]
-    @Ignore
+    // [module-java8#68]
     @Test
     public void testZoneOffsetDeserFromEmpty() throws Exception
     {

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,6 +15,8 @@ due to number of types.
 
 3.0.0 (not yet released)
 
+- #68: Parsing of `ZoneId` should respect `ALLOW_COERCION_OF_SCALARS`
+  wrt empty String
 - Deprecate "paramater names" and "datatypes" modules as functionality
   now included directly in `jackson-databind`
 - Remove legacy `JSR310Module`


### PR DESCRIPTION
The empty string handling changes for issue #138 conflicted with the fix for issue #68, so this is to restore the previous fix, where parsing of `ZoneId` should respect `ALLOW_COERCION_OF_SCALARS` wrt empty String