### PR TITLE
Support unannotated single arg constructors as property creators

### DIFF
--- a/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
+++ b/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
@@ -78,7 +78,7 @@ public class ParameterNamesAnnotationIntrospector extends NopAnnotationIntrospec
             }
             return mode;
         }
-        return null;
+        return creatorBinding;
     }
 
     @Override

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JsonCreatorTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JsonCreatorTest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import org.junit.*;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.BDDAssertions.*;
 
 public class JsonCreatorTest
@@ -25,11 +23,10 @@ public class JsonCreatorTest
 	}
 
 	@Test
-	public void shouldDeserializeUsingDefaultPropertyCreatorSetting() throws IOException {
+	public void shouldDeserializeUsingDefaultPropertyCreatorSetting() throws Exception {
 		// given
 		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new ParameterNamesModule());
-		objectMapper.configure(MapperFeature.SET_PROPERTY_CREATOR_AS_DEFAULT, true);
+		objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
 		int givenValue = 1;
 
 		// when

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JsonCreatorTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JsonCreatorTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import org.junit.*;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.BDDAssertions.*;
 
 public class JsonCreatorTest
@@ -22,6 +24,21 @@ public class JsonCreatorTest
 		then(actual).isEqualToComparingFieldByField(new ClassWithJsonCreatorOnStaticMethod("1st", "2nd"));
 	}
 
+	@Test
+	public void shouldDeserializeUsingDefaultPropertyCreatorSetting() throws IOException {
+		// given
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new ParameterNamesModule());
+		objectMapper.configure(MapperFeature.SET_PROPERTY_CREATOR_AS_DEFAULT, true);
+		int givenValue = 1;
+
+		// when
+		SinglePropertyValueClass actual = objectMapper.readValue("{\"value\":\"" + givenValue + "\"}",
+		                                                         SinglePropertyValueClass.class);
+		// then
+        then(actual).isEqualToComparingFieldByField(new SinglePropertyValueClass(givenValue));
+	}
+
 	static class ClassWithJsonCreatorOnStaticMethod {
 		final String first;
 		final String second;
@@ -35,6 +52,18 @@ public class JsonCreatorTest
 		static ClassWithJsonCreatorOnStaticMethod factory(String first, String second) {
 
 			return new ClassWithJsonCreatorOnStaticMethod(first, second);
+		}
+	}
+
+	static class SinglePropertyValueClass {
+		private final Integer value;
+
+		SinglePropertyValueClass(Integer value) {
+			this.value = value;
+		}
+
+		public Integer getValue() {
+			return value;
 		}
 	}
 }


### PR DESCRIPTION
This is a (partial) fix for #50 and follows the existing documentation which can be found on:
https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names#delegating-creator:
If the module is registered as follows:
```java
objectMapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
```
Then the given creator mode is used for constructors where no `@JsonCreator` annotation is used.
 
Includes the test from #31

I consider this a partial fix, because having this as default behaviour would be better, see https://github.com/FasterXML/jackson-databind/issues/1498