### PR TITLE
#166: Only normalize OffsetDateTimes when they are normalizable

### DIFF
--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -523,6 +523,79 @@ public class OffsetDateTimeDeserTest
     }
 
     /*
+     * Tests for the deserialization of OffsetDateTimes that cannot be
+     * normalized with ADJUST_DATES_TO_CONTEXT_TIME_ZONE enabled. The expected
+     * behaviour is that normalization is skipped for those OffsetDateTimes
+     * that cannot be normalized. See [jackson-modules-java8#166].
+     */
+
+    @Test
+    public void testDeserializationOfOffsetDateTimeMin() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.MIN;
+        OffsetDateTime value = MAPPER.readerFor(OffsetDateTime.class)
+                .with(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .readValue('"' + FORMATTER.format(date) + '"');
+        assertIsEqual(date, value);
+        assertNotEquals("The time zone has been normalized.", ZoneOffset.UTC, value.getOffset());
+    }
+
+    @Test
+    public void testDeserializationOfUnadjustableOffsetDateTimeNearMin() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.MIN.plusHours(18).minusNanos(1);
+        OffsetDateTime value = MAPPER.readerFor(OffsetDateTime.class)
+                .with(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .readValue('"' + FORMATTER.format(date) + '"');
+        assertIsEqual(date, value);
+        assertNotEquals("The time zone has been normalized.", ZoneOffset.UTC, value.getOffset());
+    }
+
+    @Test
+    public void testDeserializationOfAdjustableOffsetDateTimeNearMin() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.MIN.plusHours(18);
+        OffsetDateTime value = MAPPER.readerFor(OffsetDateTime.class)
+                .with(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .readValue('"' + FORMATTER.format(date) + '"');
+        assertIsEqual(date, value);
+        assertEquals("The time zone is not correct.", ZoneOffset.UTC, value.getOffset());
+    }
+
+    @Test
+    public void testDeserializationOfOffsetDateTimeMax() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.MAX;
+        OffsetDateTime value = MAPPER.readerFor(OffsetDateTime.class)
+                .with(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .readValue('"' + FORMATTER.format(date) + '"');
+        assertIsEqual(date, value);
+        assertNotEquals("The time zone has been normalized.", ZoneOffset.UTC, value.getOffset());
+    }
+
+    @Test
+    public void testDeserializationOfUnadjustableOffsetDateTimeNearMax() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.MAX.minusHours(18).plusNanos(1);
+        OffsetDateTime value = MAPPER.readerFor(OffsetDateTime.class)
+                .with(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .readValue('"' + FORMATTER.format(date) + '"');
+        assertIsEqual(date, value);
+        assertNotEquals("The time zone has been normalized.", ZoneOffset.UTC, value.getOffset());
+    }
+
+    @Test
+    public void testDeserializationOfAdjustableOffsetDateTimeNearMax() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.MAX.minusHours(18);
+        OffsetDateTime value = MAPPER.readerFor(OffsetDateTime.class)
+                .with(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .readValue('"' + FORMATTER.format(date) + '"');
+        assertIsEqual(date, value);
+        assertEquals("The time zone is not correct.", ZoneOffset.UTC, value.getOffset());
+    }
+
+    /*
     /**********************************************************
     /* Tests for empty string handling
     /**********************************************************


### PR DESCRIPTION
Possible fix for #166. This commit adds a check before the OffsetDateTime adjustment of ADJUST_DATES_TO_CONTEXT_TIME_ZONE that ensures that the OffsetDateTime is normalizeable given a specific time zone offset. When it is not, normalization is skipped and the un-adjusted OffsetDateTime is returned.