### PR TITLE
Fix #175 ObjectMapper#setTimeZone ignored by JSR-310/datetime types during serialization

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
@@ -121,8 +121,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     }
 
     @Override // since 2.9
-    protected JsonToken serializationShape(SerializerProvider provider)
-    {
+    protected JsonToken serializationShape(SerializerProvider provider) {
         if (useTimestamp(provider)) {
             if (useNanoseconds(provider)) {
                 return JsonToken.VALUE_NUMBER_FLOAT;
@@ -142,11 +141,10 @@ public abstract class InstantSerializerBase<T extends Temporal>
         }
 
         ZoneId zone = provider.getTimeZone().toZoneId();
-        if (formatter != null && formatter.getZone() != null) {
-            zone = formatter.getZone();
-        }
-
         if (formatter != null) {
+            if (formatter.getZone() != null) {
+                zone = formatter.getZone();
+            }
             return formatter.withZone(zone).format(value);
         }
 

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
@@ -18,6 +18,7 @@ package com.fasterxml.jackson.datatype.jsr310.ser;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.function.ToIntFunction;
@@ -42,7 +43,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     extends JSR310FormattedSerializerBase<T>
 {
     private final DateTimeFormatter defaultFormat;
-    
+
     private final ToLongFunction<T> getEpochMillis;
 
     private final ToLongFunction<T> getEpochSeconds;
@@ -96,15 +97,8 @@ public abstract class InstantSerializerBase<T extends Temporal>
             generator.writeNumber(getEpochMillis.applyAsLong(value));
             return;
         }
-        String str;
-        
-        if (_formatter != null) {
-            str = _formatter.format(value);;
-        } else if (defaultFormat != null) {
-            str = defaultFormat.format(value);;
-        } else {
-            str = value.toString();
-        }
+
+        String str = formatValue(value, provider);
         generator.writeString(str);
     }
 
@@ -127,7 +121,8 @@ public abstract class InstantSerializerBase<T extends Temporal>
     }
 
     @Override // since 2.9
-    protected JsonToken serializationShape(SerializerProvider provider) {
+    protected JsonToken serializationShape(SerializerProvider provider)
+    {
         if (useTimestamp(provider)) {
             if (useNanoseconds(provider)) {
                 return JsonToken.VALUE_NUMBER_FLOAT;
@@ -135,5 +130,26 @@ public abstract class InstantSerializerBase<T extends Temporal>
             return JsonToken.VALUE_NUMBER_INT;
         }
         return JsonToken.VALUE_STRING;
+    }
+
+    private String formatValue(T value, SerializerProvider provider)
+    {
+        DateTimeFormatter formatter = null;
+        if (_formatter != null) {
+            formatter = _formatter;
+        } else if (defaultFormat != null) {
+            formatter = defaultFormat;
+        }
+
+        ZoneId zone = provider.getTimeZone().toZoneId();
+        if (formatter != null && formatter.getZone() != null) {
+            zone = formatter.getZone();
+        }
+
+        if (formatter != null) {
+            return formatter.withZone(zone).format(value);
+        }
+
+        return value.toString();
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/old/TestOffsetDateTimeSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/old/TestOffsetDateTimeSerialization.java
@@ -42,6 +42,8 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
 {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
+    private static final DateTimeFormatter FORMATTER_UTC = FORMATTER.withZone(ZoneOffset.UTC);
+
     private static final ZoneId Z1 = ZoneId.of("America/Chicago");
 
     private static final ZoneId Z2 = ZoneId.of("America/Anchorage");
@@ -143,7 +145,7 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
         String value = this.mapper.writeValueAsString(date);
 
         assertNotNull("The value should not be null.", value);
-        assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
     }
 
     @Test
@@ -155,7 +157,7 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
         String value = this.mapper.writeValueAsString(date);
 
         assertNotNull("The value should not be null.", value);
-        assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
     }
 
     @Test
@@ -165,6 +167,48 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
 
         this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         String value = this.mapper.writeValueAsString(date);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+    }
+
+    @Test
+    public void testSerializationAsStringWithMapperTimeZone01() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(0L), Z1);
+
+        String value = newMapper()
+                .setTimeZone(TimeZone.getTimeZone(Z1))
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .writeValueAsString(date);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
+    }
+
+    @Test
+    public void testSerializationAsStringWithMapperTimeZone02() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
+
+        String value = newMapper()
+                .setTimeZone(TimeZone.getTimeZone(Z2))
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .writeValueAsString(date);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
+    }
+
+    @Test
+    public void testSerializationAsStringWithMapperTimeZone03() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.now(Z3);
+
+        String value = newMapper()
+                .setTimeZone(TimeZone.getTimeZone(Z3))
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .writeValueAsString(date);
 
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
@@ -211,7 +255,23 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
 
         assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.",
-                "[\"" + OffsetDateTime.class.getName() + "\",\"" + FORMATTER.format(date) + "\"]", value);
+                "[\"" + OffsetDateTime.class.getName() + "\",\"" + FORMATTER_UTC.format(date) + "\"]", value);
+    }
+
+    @Test
+    public void testSerializationWithTypeInfoAndMapperTimeZone() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.now(Z3);
+
+        String value = newMapper()
+                .setTimeZone(TimeZone.getTimeZone(Z3))
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .addMixIn(Temporal.class, MockObjectConfiguration.class)
+                .writeValueAsString(date);
+
+        assertNotNull("The value should not be null.", value);
+        assertEquals("The value is not correct.",
+            "[\"" + OffsetDateTime.class.getName() + "\",\"" + FORMATTER.format(date) + "\"]", value);
     }
 
     @Test

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/TestZonedDateTimeSerializationWithCustomFormatter.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/TestZonedDateTimeSerializationWithCustomFormatter.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -27,7 +28,8 @@ public class TestZonedDateTimeSerializationWithCustomFormatter {
     @Test
     public void testSerialization() throws Exception {
         ZonedDateTime zonedDateTime = ZonedDateTime.now();
-        assertThat(serializeWith(zonedDateTime, formatter), containsString(zonedDateTime.format(formatter)));
+        assertThat(serializeWith(zonedDateTime, formatter),
+                containsString(zonedDateTime.format(formatter.withZone(ZoneOffset.UTC))));
     }
 
     private String serializeWith(ZonedDateTime zonedDateTime, DateTimeFormatter f) throws Exception {


### PR DESCRIPTION
Probably will fix #180 as well.

As the discussion at #175 pointed out this logic already exists in `jackson-datatype-joda`, I checked what is happening there as a starting point. I felt adopting something like `JacksonJodaDateFormat` to here would be a pretty large and complex change, I just added the check for the mapper time zone to the `JSR310FormattedSerializerBase#serialize(...)` method.

This changes the serialization behavior a bit. If a zoned date-time value is provided for serialization and there is no explicit time zone setting for the `ObjectMapper` (which means UTC) or any other format (e.g. POJO annotation), then the serialized string will be converted to UTC. Since `jackson-datatype-joda` works the same way, I felt okay with that.

I adapted every related unit test and added new ones to cover new cases.