### PR TITLE
Implement #188: only override timezone/offset if explicitly defined default offset/tz

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
@@ -16,17 +16,18 @@
 
 package com.fasterxml.jackson.datatype.jsr310.ser;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.io.IOException;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
+
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -134,19 +135,17 @@ public abstract class InstantSerializerBase<T extends Temporal>
     // @since 2.12
     protected String formatValue(T value, SerializerProvider provider)
     {
-        DateTimeFormatter formatter = null;
-        if (_formatter != null) {
-            formatter = _formatter;
-        } else if (defaultFormat != null) {
-            formatter = defaultFormat;
-        }
-
+        DateTimeFormatter formatter = (_formatter != null) ? _formatter : defaultFormat;
         if (formatter != null) {
-            ZoneId zone = formatter.getZone();
-            if (zone == null) {
-                zone = provider.getTimeZone().toZoneId();
+            if (formatter.getZone() == null) { // timezone set if annotated on property
+                // 19-Oct-2020, tatu: As per [modules-java#188], only override with explicitly
+                //     set timezone, to minimize change from pre-2.12. May need to further
+                //     improve in future to maybe introduce more configuration.
+                if (provider.getConfig().hasExplicitTimeZone()) {
+                    formatter = formatter.withZone(provider.getTimeZone().toZoneId());
+                }
             }
-            return formatter.withZone(zone).format(value);
+            return formatter.format(value);
         }
 
         return value.toString();

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/old/TestOffsetDateTimeSerialization.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/old/TestOffsetDateTimeSerialization.java
@@ -127,12 +127,10 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationAsTimestamp03Milliseconds() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
-        this.mapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
+        String value = mapper.writer()
+                .with(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .without(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .writeValueAsString(date);
         assertEquals("The value is not correct.", Long.toString(date.toInstant().toEpochMilli()), value);
     }
 
@@ -140,49 +138,43 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationAsString01() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(0L), Z1);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        String value = mapper.writer()
+                .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .writeValueAsString(date);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z1).format(date) + '"', value);
     }
 
     @Test
     public void testSerializationAsString02() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        String value = mapper.writer()
+                .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .writeValueAsString(date);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z2).format(date) + '"', value);
     }
 
     @Test
     public void testSerializationAsString03() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        String value = mapper.writer()
+                .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .writeValueAsString(date);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z3).format(date) + '"', value);
     }
 
     @Test
     public void testSerializationAsStringWithMapperTimeZone01() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(0L), Z1);
-
         String value = newMapper()
                 .setTimeZone(TimeZone.getTimeZone(Z1))
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
     }
 
@@ -190,13 +182,10 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationAsStringWithMapperTimeZone02() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
-
         String value = newMapper()
                 .setTimeZone(TimeZone.getTimeZone(Z2))
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
     }
 
@@ -204,13 +193,10 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationAsStringWithMapperTimeZone03() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
-
         String value = newMapper()
                 .setTimeZone(TimeZone.getTimeZone(Z3))
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.", '"' + FORMATTER.format(date) + '"', value);
     }
 
@@ -218,13 +204,11 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationWithTypeInfo01() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
-        this.mapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, true);
-        this.mapper.addMixIn(Temporal.class, MockObjectConfiguration.class);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
+        String value = newMapper()
+                .addMixIn(Temporal.class, MockObjectConfiguration.class)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
+                .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, true)
+                .writeValueAsString(date);
         assertEquals("The value is not correct.",
                 "[\"" + OffsetDateTime.class.getName() + "\",123456789.183917322]", value);
     }
@@ -233,13 +217,11 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationWithTypeInfo02() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
-        this.mapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
-        this.mapper.addMixIn(Temporal.class, MockObjectConfiguration.class);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
+        String value = newMapper()
+                .addMixIn(Temporal.class, MockObjectConfiguration.class)
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
+                .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+                .writeValueAsString(date);
         assertEquals("The value is not correct.",
                 "[\"" + OffsetDateTime.class.getName() + "\",123456789183]", value);
     }
@@ -248,14 +230,13 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
     public void testSerializationWithTypeInfo03() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
-
-        this.mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        this.mapper.addMixIn(Temporal.class, MockObjectConfiguration.class);
-        String value = this.mapper.writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
+        String value = newMapper()
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .addMixIn(Temporal.class, MockObjectConfiguration.class)
+                .writeValueAsString(date);
         assertEquals("The value is not correct.",
-                "[\"" + OffsetDateTime.class.getName() + "\",\"" + FORMATTER_UTC.format(date) + "\"]", value);
+                "[\"" + OffsetDateTime.class.getName() + "\",\"" +
+                        FORMATTER_UTC.withZone(Z3).format(date) + "\"]", value);
     }
 
     @Test
@@ -268,8 +249,6 @@ public class TestOffsetDateTimeSerialization extends ModuleTestBase
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .addMixIn(Temporal.class, MockObjectConfiguration.class)
                 .writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.",
             "[\"" + OffsetDateTime.class.getName() + "\",\"" + FORMATTER.format(date) + "\"]", value);
     }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/OffsetDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/OffsetDateTimeSerTest.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.datatype.jsr310.ser;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.TimeZone;
@@ -18,14 +17,11 @@ import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class OffsetDateTimeSerTest
     extends ModuleTestBase
 {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-
-    private static final DateTimeFormatter FORMATTER_UTC = FORMATTER.withZone(ZoneOffset.UTC);
 
     private static final ZoneId Z1 = ZoneId.of("America/Chicago");
 
@@ -118,7 +114,8 @@ public class OffsetDateTimeSerTest
         String value = MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .writeValueAsString(date);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z1).format(date) + '"', value);
     }
 
     @Test
@@ -128,7 +125,8 @@ public class OffsetDateTimeSerTest
         String value = MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .writeValueAsString(date);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z2).format(date) + '"', value);
     }
 
     @Test
@@ -138,7 +136,8 @@ public class OffsetDateTimeSerTest
         String value = MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .writeValueAsString(date);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z3).format(date) + '"', value);
     }
 
     @Test
@@ -213,9 +212,9 @@ public class OffsetDateTimeSerTest
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             .addMixIn(Temporal.class, MockObjectConfiguration.class)
             .writeValueAsString(date);
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.",
-            "[\"" + OffsetDateTime.class.getName() + "\",\"" + FORMATTER_UTC.format(date) + "\"]", value);
+            "[\"" + OffsetDateTime.class.getName() + "\",\""
+                    + FORMATTER.withZone(Z3).format(date) + "\"]", value);
     }
 
     @Test

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/TestZonedDateTimeSerializationWithCustomFormatter.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/TestZonedDateTimeSerializationWithCustomFormatter.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.datatype.jsr310.ser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,6 +14,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.TimeZone;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
@@ -33,9 +35,12 @@ public class TestZonedDateTimeSerializationWithCustomFormatter {
     }
 
     private String serializeWith(ZonedDateTime zonedDateTime, DateTimeFormatter f) throws Exception {
-        ObjectMapper mapper = new ObjectMapper().registerModule(new SimpleModule().addSerializer(
-                new ZonedDateTimeSerializer(f)));
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        ObjectMapper mapper = JsonMapper.builder()
+                .addModule(new SimpleModule().addSerializer(
+                        new ZonedDateTimeSerializer(f)))
+                .defaultTimeZone(TimeZone.getTimeZone("UTC"))
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
         return mapper.writeValueAsString(zonedDateTime);
     }
 

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
@@ -16,13 +16,8 @@
 
 package com.fasterxml.jackson.datatype.jsr310.ser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -40,12 +35,14 @@ import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 public class ZonedDateTimeSerTest
     extends ModuleTestBase
 {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-
-    private static final DateTimeFormatter FORMATTER_UTC = FORMATTER.withZone(ZoneOffset.UTC);
 
     private static final ZoneId Z1 = ZoneId.of("America/Chicago");
 
@@ -178,7 +175,8 @@ public class ZonedDateTimeSerTest
         String value = MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .writeValueAsString(date);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z1).format(date) + '"', value);
     }
 
     @Test
@@ -188,7 +186,8 @@ public class ZonedDateTimeSerTest
         String value = MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .writeValueAsString(date);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z2).format(date) + '"', value);
     }
 
     @Test
@@ -198,7 +197,8 @@ public class ZonedDateTimeSerTest
         String value = MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .writeValueAsString(date);
-        assertEquals("The value is not correct.", '"' + FORMATTER_UTC.format(date) + '"', value);
+        assertEquals("The value is not correct.", '"'
+                + FORMATTER.withZone(Z3).format(date) + '"', value);
     }
 
     @Test
@@ -242,7 +242,8 @@ public class ZonedDateTimeSerTest
                         SerializationFeature.WRITE_DATES_WITH_ZONE_ID)
                 .writeValueAsString(date);
 
-        assertEquals("The value is incorrect.", "\"" + FORMATTER_UTC.format(date) + "\"", value);
+        assertEquals("The value is incorrect.", "\""
+                + FORMATTER.withZone(Z3).format(date) + "\"", value);
     }
 
     @Test
@@ -300,16 +301,14 @@ public class ZonedDateTimeSerTest
     public void testSerializationWithTypeInfo03() throws Exception
     {
         ZonedDateTime date = ZonedDateTime.now(Z3);
-
         String value = mapperBuilder()
                 .addMixIn(Temporal.class, MockObjectConfiguration.class)
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build()
                 .writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.",
-                "[\"" + ZonedDateTime.class.getName() + "\",\"" + FORMATTER_UTC.format(date) + "\"]", value);
+                "[\"" + ZonedDateTime.class.getName() + "\",\""
+                        + FORMATTER.withZone(Z3).format(date) + "\"]", value);
     }
 
     @Test
@@ -323,8 +322,6 @@ public class ZonedDateTimeSerTest
                 .writer()
                 .with(TimeZone.getTimeZone(Z3))
                 .writeValueAsString(date);
-
-        assertNotNull("The value should not be null.", value);
         assertEquals("The value is not correct.",
             "[\"" + ZonedDateTime.class.getName() + "\",\"" + FORMATTER.format(date) + "\"]", value);
     }


### PR DESCRIPTION
As per title, try to reduce scope of #175 using new configuration setting.