### PR TITLE
Support pattern for duration serializer

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerializer.java
@@ -21,14 +21,17 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
 import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
+import com.fasterxml.jackson.datatype.jsr310.util.DurationUnitConverter;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -52,6 +55,16 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
 
     public static final DurationSerializer INSTANCE = new DurationSerializer();
 
+    /**
+     * When defined (not {@code null}) duration values will be converted into integers
+     * with the unit configured for the converter.
+     * Only available when {@link SerializationFeature#WRITE_DURATIONS_AS_TIMESTAMPS} is enabled
+     * and {@link SerializationFeature#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS} is not enabled
+     * since the duration converters do not support fractions
+     * @since 2.12
+     */
+    private DurationUnitConverter _durationUnitConverter;
+
     private DurationSerializer() {
         super(Duration.class);
     }
@@ -66,9 +79,18 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
         super(base, useTimestamp, useNanoseconds, dtf, null);
     }
 
+    protected DurationSerializer(DurationSerializer base, DurationUnitConverter converter) {
+        super(base, base._useTimestamp, base._useNanoseconds, base._formatter, base._shape);
+        _durationUnitConverter = converter;
+    }
+
     @Override
     protected DurationSerializer withFormat(Boolean useTimestamp, DateTimeFormatter dtf, JsonFormat.Shape shape) {
         return new DurationSerializer(this, useTimestamp, dtf);
+    }
+
+    protected DurationSerializer withConverter(DurationUnitConverter converter) {
+        return new DurationSerializer(this, converter);
     }
 
     // @since 2.10
@@ -78,31 +100,57 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
     }
 
     @Override
+    public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) throws JsonMappingException {
+        DurationSerializer ser = (DurationSerializer) super.createContextual(prov, property);
+        JsonFormat.Value format = findFormatOverrides(prov, property, handledType());
+        if (format != null && format.hasPattern()) {
+            final String pattern = format.getPattern();
+            DurationUnitConverter p = DurationUnitConverter.from(pattern);
+            if (p == null) {
+                prov.reportBadDefinition(handledType(),
+                        String.format(
+                                "Bad 'pattern' definition (\"%s\") for `Duration`: expected one of [%s]",
+                                pattern, DurationUnitConverter.descForAllowed()));
+            }
+
+            ser = ser.withConverter(p);
+        }
+        return ser;
+    }
+
+    @Override
     public void serialize(Duration duration, JsonGenerator generator, SerializerProvider provider) throws IOException
     {
         if (useTimestamp(provider)) {
             if (useNanoseconds(provider)) {
-                // 20-Oct-2020, tatu: [modules-java8#165] Need to take care of
-                //    negative values too, and without work-around values
-                //    returned are wonky wrt conversions
-                BigDecimal bd;
-                if (duration.isNegative()) {
-                    duration = duration.abs();
-                    bd = DecimalUtils.toBigDecimal(duration.getSeconds(),
-                            duration.getNano())
-                        .negate();
-                } else {
-                    bd = DecimalUtils.toBigDecimal(duration.getSeconds(),
-                            duration.getNano());
-                }
-                generator.writeNumber(bd);
+                generator.writeNumber(_toNanos(duration));
             } else {
-                generator.writeNumber(duration.toMillis());
+                if (_durationUnitConverter != null) {
+                    generator.writeNumber(_durationUnitConverter.convert(duration));
+                } else {
+                    generator.writeNumber(duration.toMillis());
+                }
             }
         } else {
-            // Does not look like we can make any use of DateTimeFormatter here?
             generator.writeString(duration.toString());
         }
+    }
+
+    // 20-Oct-2020, tatu: [modules-java8#165] Need to take care of
+    //    negative values too, and without work-around values
+    //    returned are wonky wrt conversions
+    private BigDecimal _toNanos(Duration duration) {
+        BigDecimal bd;
+        if (duration.isNegative()) {
+            duration = duration.abs();
+            bd = DecimalUtils.toBigDecimal(duration.getSeconds(),
+                    duration.getNano())
+                .negate();
+        } else {
+            bd = DecimalUtils.toBigDecimal(duration.getSeconds(),
+                    duration.getNano());
+        }
+        return bd;
     }
 
     @Override
@@ -134,5 +182,10 @@ public class DurationSerializer extends JSR310FormattedSerializerBase<Duration>
     @Override
     protected JSR310FormattedSerializerBase<?> withFeatures(Boolean writeZoneId, Boolean writeNanoseconds) {
         return new DurationSerializer(this, _useTimestamp, writeNanoseconds, _formatter);
+    }
+
+    @Override
+    protected DateTimeFormatter _useDateTimeFormatter(SerializerProvider prov, JsonFormat.Value format) {
+        return null;
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/JSR310FormattedSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/JSR310FormattedSerializerBase.java
@@ -144,18 +144,7 @@ abstract class JSR310FormattedSerializerBase<T>
 
             // If not, do we have a pattern?
             if (format.hasPattern()) {
-                final String pattern = format.getPattern();
-                final Locale locale = format.hasLocale() ? format.getLocale() : prov.getLocale();
-                if (locale == null) {
-                    dtf = DateTimeFormatter.ofPattern(pattern);
-                } else {
-                    dtf = DateTimeFormatter.ofPattern(pattern, locale);
-                }
-                //Issue #69: For instant serializers/deserializers we need to configure the formatter with
-                //a time zone picked up from JsonFormat annotation, otherwise serialization might not work
-                if (format.hasTimeZone()) {
-                    dtf = dtf.withZone(format.getTimeZone().toZoneId());
-                }
+                dtf = _useDateTimeFormatter(prov, format);
             }
             JSR310FormattedSerializerBase<?> ser = this;
             if ((shape != _shape) || (useTimestamp != _useTimestamp) || (dtf != _formatter)) {
@@ -211,7 +200,7 @@ abstract class JSR310FormattedSerializerBase<T>
         }
         return t;
     }
-    
+
     /**
      * Overridable method that determines {@link SerializationFeature} that is used as
      * the global default in determining if date/time value serialized should use numeric
@@ -264,5 +253,23 @@ abstract class JSR310FormattedSerializerBase<T>
         }
         return (provider != null)
                 && provider.isEnabled(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+    }
+
+    // modules-java8#189: to be overridden by other formatters using this as base class
+    protected DateTimeFormatter _useDateTimeFormatter(SerializerProvider prov, JsonFormat.Value format) {
+        DateTimeFormatter dtf;
+        final String pattern = format.getPattern();
+        final Locale locale = format.hasLocale() ? format.getLocale() : prov.getLocale();
+        if (locale == null) {
+            dtf = DateTimeFormatter.ofPattern(pattern);
+        } else {
+            dtf = DateTimeFormatter.ofPattern(pattern, locale);
+        }
+        //Issue #69: For instant serializers/deserializers we need to configure the formatter with
+        //a time zone picked up from JsonFormat annotation, otherwise serialization might not work
+        if (format.hasTimeZone()) {
+            dtf = dtf.withZone(format.getTimeZone().toZoneId());
+        }
+        return dtf;
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/util/DurationUnitConverter.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/util/DurationUnitConverter.java
@@ -10,7 +10,13 @@ import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.datatype.jsr310.util.DurationUnitConverter.DurationSerialization.deserializer;
 
-
+/**
+ * Handles the conversion of the duration based on the API of {@link Duration} for a restricted set of {@link ChronoUnit}.
+ * Only the units considered as accurate are supported in this converter since are the only ones capable of handling
+ * deserialization in a precise manner (see {@link ChronoUnit#isDurationEstimated}).
+ *
+ * @since 2.12
+ */
 public class DurationUnitConverter {
 
     protected static class DurationSerialization {

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/util/DurationUnitConverter.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/util/DurationUnitConverter.java
@@ -1,0 +1,76 @@
+package com.fasterxml.jackson.datatype.jsr310.util;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.datatype.jsr310.util.DurationUnitConverter.DurationSerialization.deserializer;
+
+
+public class DurationUnitConverter {
+
+    protected static class DurationSerialization {
+        final Function<Duration, Long> serializer;
+        final Function<Long, Duration> deserializer;
+
+        DurationSerialization(
+                Function<Duration, Long> serializer,
+                Function<Long, Duration> deserializer) {
+            this.serializer = serializer;
+            this.deserializer = deserializer;
+        }
+
+        static Function<Long, Duration> deserializer(TemporalUnit unit) {
+            return v -> Duration.of(v, unit);
+        }
+    }
+
+    private final static Map<String, DurationSerialization> UNITS;
+
+    static {
+        Map<String, DurationSerialization> units = new LinkedHashMap<>();
+        units.put(ChronoUnit.NANOS.name(), new DurationSerialization(Duration::toNanos, deserializer(ChronoUnit.NANOS)));
+        units.put(ChronoUnit.MICROS.name(), new DurationSerialization(d -> d.toNanos() / 1000, deserializer(ChronoUnit.MICROS)));
+        units.put(ChronoUnit.MILLIS.name(), new DurationSerialization(Duration::toMillis, deserializer(ChronoUnit.MILLIS)));
+        units.put(ChronoUnit.SECONDS.name(), new DurationSerialization(Duration::getSeconds, deserializer(ChronoUnit.SECONDS)));
+        units.put(ChronoUnit.MINUTES.name(), new DurationSerialization(Duration::toMinutes, deserializer(ChronoUnit.MINUTES)));
+        units.put(ChronoUnit.HOURS.name(), new DurationSerialization(Duration::toHours, deserializer(ChronoUnit.HOURS)));
+        units.put(ChronoUnit.HALF_DAYS.name(), new DurationSerialization(d -> d.toHours() / 12, deserializer(ChronoUnit.HALF_DAYS)));
+        units.put(ChronoUnit.DAYS.name(), new DurationSerialization(Duration::toDays, deserializer(ChronoUnit.DAYS)));
+        UNITS = units;
+    }
+
+
+    final DurationSerialization serialization;
+
+    DurationUnitConverter(DurationSerialization serialization) {
+        this.serialization = serialization;
+    }
+
+    public Duration convert(long value) {
+        return serialization.deserializer.apply(value);
+    }
+
+    public long convert(Duration duration) {
+        return serialization.serializer.apply(duration);
+    }
+
+    /**
+     * @return Description of all allowed valued as a sequence of
+     * double-quoted values separated by comma
+     */
+    public static String descForAllowed() {
+        return "\"" + UNITS.keySet().stream()
+                .collect(Collectors.joining("\", \""))
+                + "\"";
+    }
+
+    public static DurationUnitConverter from(String unit) {
+        DurationSerialization def = UNITS.get(unit);
+        return (def == null) ? null : new DurationUnitConverter(def);
+    }
+}

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/DurationSerTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.datatype.jsr310.ser;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -160,5 +161,186 @@ public class DurationSerTest extends ModuleTestBase
 
         assertEquals("The value is not correct.",
                 "[\"" + Duration.class.getName() + "\",\"" + duration.toString() + "\"]", value);
+    }
+
+    /*
+    /**********************************************************
+    /* Tests for custom patterns (modules-java8#189)
+    /**********************************************************
+     */
+
+    @Test
+    public void shouldSerializeInNanos_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("NANOS");
+
+        Duration duration = Duration.ofHours(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "3600000000000", value);
+    }
+
+    @Test
+    public void shouldSerializeInMicros_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("MICROS");
+
+        Duration duration = Duration.ofMillis(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1000", value);
+    }
+
+    @Test
+    public void shouldSerializeInMicrosDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("MICROS");
+
+        Duration duration = Duration.ofNanos(1500);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInMillis_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("MILLIS");
+
+        Duration duration = Duration.ofSeconds(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1000", value);
+    }
+
+    @Test
+    public void shouldSerializeInMillisDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("MILLIS");
+
+        Duration duration = Duration.ofNanos(1500000);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInSeconds_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("SECONDS");
+
+        Duration duration = Duration.ofMinutes(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "60", value);
+    }
+
+    @Test
+    public void shouldSerializeInSecondsDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("SECONDS");
+
+        Duration duration = Duration.ofMillis(1500);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInMinutes_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("MINUTES");
+
+        Duration duration = Duration.ofHours(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "60", value);
+    }
+
+    @Test
+    public void shouldSerializeInMinutesDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("MINUTES");
+
+        Duration duration = Duration.ofSeconds(90);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInHours_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("HOURS");
+
+        Duration duration = Duration.ofDays(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "24", value);
+    }
+
+    @Test
+    public void shouldSerializeInHoursDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("HOURS");
+
+        Duration duration = Duration.ofMinutes(90);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInHalfDays_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("HALF_DAYS");
+
+        Duration duration = Duration.ofDays(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "2", value);
+    }
+
+    @Test
+    public void shouldSerializeInHalfDaysDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("DAYS");
+
+        Duration duration = Duration.ofHours(30);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInDays_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("DAYS");
+
+        Duration duration = Duration.ofDays(1);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    @Test
+    public void shouldSerializeInDaysDiscardingFractions_whenSetAsPattern() throws Exception
+    {
+        ObjectMapper mapper = _mapperForPatternOverride("DAYS");
+
+        Duration duration = Duration.ofHours(36);
+        String value = mapper.writeValueAsString(duration);
+
+        assertEquals("The value is not correct.", "1", value);
+    }
+
+    protected ObjectMapper _mapperForPatternOverride(String pattern) {
+        ObjectMapper mapper = mapperBuilder()
+                .enable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                .build();
+        mapper.configOverride(Duration.class)
+                .setFormat(JsonFormat.Value.forPattern(pattern));
+        return mapper;
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/util/DurationUnitConverterTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/util/DurationUnitConverterTest.java
@@ -1,6 +1,5 @@
-package com.fasterxml.jackson.datatype.jsr310.deser;
+package com.fasterxml.jackson.datatype.jsr310.util;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -9,7 +8,6 @@ import java.time.temporal.ChronoUnit;
 import org.junit.Test;
 
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
-import com.fasterxml.jackson.datatype.jsr310.deser.DurationDeserializer.DurationUnitConverter;
 
 public class DurationUnitConverterTest
     extends ModuleTestBase
@@ -28,7 +26,6 @@ public class DurationUnitConverterTest
         }) {
             DurationUnitConverter conv = DurationUnitConverter.from(inputUnit.name());
             assertNotNull(conv);
-            assertEquals(inputUnit, conv.unit);
             // is case-sensitive:
             assertNull(DurationUnitConverter.from(inputUnit.name().toLowerCase()));
         }


### PR DESCRIPTION
Does not support duration serialization with fractions (see comments in #189). I would propose to merge first this so we can iterate and add fractions feature in the future.