### PR TITLE
Fix OptionalDouble deserialization of special values without coercion

### DIFF
--- a/datatypes/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalDoubleDeserializer.java
+++ b/datatypes/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalDoubleDeserializer.java
@@ -32,6 +32,14 @@ class OptionalDoubleDeserializer extends BaseScalarOptionalDeserializer<Optional
         switch (p.currentTokenId()) {
         case JsonTokenId.ID_STRING:
             String text = p.getText();
+            // 19-Nov-2020, ckozak: see jackson-databind#2942: Special case, floating point special
+            //     values as String (e.g. "NaN", "Infinity", "-Infinity" need to be considered
+            //     "native" representation as JSON does not allow as numbers, and hence not bound
+            //     by coercion rules
+            Double specialValue = _checkDoubleNaN(text);
+            if (specialValue != null) {
+                return OptionalDouble.of(specialValue);
+            }
             CoercionAction act = _checkFromStringCoercion(ctxt, text);
             // null and empty both same
             if ((act == CoercionAction.AsNull) || (act == CoercionAction.AsEmpty)) {

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalNumbersTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalNumbersTest.java
@@ -5,7 +5,12 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 
 public class OptionalNumbersTest extends ModuleTestBase
 {
@@ -37,6 +42,7 @@ public class OptionalNumbersTest extends ModuleTestBase
     }
 
     private ObjectMapper MAPPER = mapperWithModule();
+    private ObjectMapper MAPPER_WITHOUT_COERCION = MAPPER.copy().disable(MapperFeature.ALLOW_COERCION_OF_SCALARS);
 
     /*
     /**********************************************************
@@ -186,5 +192,70 @@ public class OptionalNumbersTest extends ModuleTestBase
         bean = MAPPER.readValue(aposToQuotes("{'value':'0.5'}"), OptionalDoubleBean.class);
         assertNotNull(bean.value);
         assertEquals(0.5, bean.value.getAsDouble());
+    }
+
+    public void testOptionalDoubleInArraySpecialValues() throws Exception
+    {
+        OptionalDouble[] actual = MAPPER.readValue(
+                "[null,\"NaN\",\"Infinity\",\"-Infinity\",1,\"2\"]",
+                OptionalDouble[].class);
+        OptionalDouble[] expected = new OptionalDouble[] {
+                OptionalDouble.empty(),
+                OptionalDouble.of(Double.NaN),
+                OptionalDouble.of(Double.POSITIVE_INFINITY),
+                OptionalDouble.of(Double.NEGATIVE_INFINITY),
+                OptionalDouble.of(1D),
+                OptionalDouble.of(2D)
+        };
+        assertArrayEquals(expected, actual);
+    }
+
+    public void testOptionalDoubleInArraySpecialValuesWithoutCoercion() throws Exception
+    {
+        OptionalDouble[] actual = MAPPER_WITHOUT_COERCION.readValue(
+                aposToQuotes("[null,'NaN','Infinity','-Infinity',1]"),
+                OptionalDouble[].class);
+        OptionalDouble[] expected = new OptionalDouble[] {
+                OptionalDouble.empty(),
+                OptionalDouble.of(Double.NaN),
+                OptionalDouble.of(Double.POSITIVE_INFINITY),
+                OptionalDouble.of(Double.NEGATIVE_INFINITY),
+                OptionalDouble.of(1D)
+        };
+        assertArrayEquals(expected, actual);
+    }
+
+    public void testQuotedOptionalDoubleWithoutCoercion()
+    {
+        assertThrows(MismatchedInputException.class,
+                () -> MAPPER_WITHOUT_COERCION.readValue(aposToQuotes("['1']"), OptionalDouble[].class));
+    }
+
+    public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_null() throws Exception
+    {
+        OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
+                aposToQuotes("{'value':null}"), OptionalDoubleBean.class);
+        assertEquals(OptionalDouble.empty(), bean.value);
+    }
+
+    public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_nan() throws Exception
+    {
+        OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
+                aposToQuotes("{'value':'NaN'}"), OptionalDoubleBean.class);
+        assertEquals(OptionalDouble.of(Double.NaN), bean.value);
+    }
+
+    public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_positiveInfinity() throws Exception
+    {
+        OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
+                aposToQuotes("{'value':'Infinity'}"), OptionalDoubleBean.class);
+        assertEquals(OptionalDouble.of(Double.POSITIVE_INFINITY), bean.value);
+    }
+
+    public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_negativeInfinity() throws Exception
+    {
+        OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
+                aposToQuotes("{'value':'-Infinity'}"), OptionalDoubleBean.class);
+        assertEquals(OptionalDouble.of(Double.NEGATIVE_INFINITY), bean.value);
     }
 }


### PR DESCRIPTION
floating point special values as JSON Strings are considered "native"
because they cannot be represented as JSON numbers.

See:
https://github.com/FasterXML/jackson-databind/pull/2942
https://github.com/FasterXML/jackson-databind/commit/7705d35fc0f58e5aec389b2cdadf9a046a55b00b