### PR TITLE
Fix #196 ZonedDateTime deserialization skipped @JsonFormat features o…

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -187,15 +187,13 @@ public class InstantDeserializer<T extends Temporal>
     {
         InstantDeserializer<T> deserializer =
                 (InstantDeserializer<T>)super.createContextual(ctxt, property);
-        if (deserializer != this) {
-            JsonFormat.Value val = findFormatOverrides(ctxt, property, handledType());
-            if (val != null) {
-                deserializer = new InstantDeserializer<>(deserializer, val.getFeature(JsonFormat.Feature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE));
-                if (val.hasLenient()) {
-                    Boolean leniency = val.getLenient();
-                    if (leniency != null) {
-                        deserializer = deserializer.withLeniency(leniency);
-                    }
+        JsonFormat.Value val = findFormatOverrides(ctxt, property, handledType());
+        if (val != null) {
+            deserializer = new InstantDeserializer<>(deserializer, val.getFeature(JsonFormat.Feature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE));
+            if (val.hasLenient()) {
+                Boolean leniency = val.getLenient();
+                if (leniency != null) {
+                    deserializer = deserializer.withLeniency(leniency);
                 }
             }
         }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ModuleTestBase.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ModuleTestBase.java
@@ -3,6 +3,7 @@ package com.fasterxml.jackson.datatype.jsr310;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -40,6 +41,7 @@ public class ModuleTestBase
 
     protected static JsonMapper.Builder mapperBuilder() {
         return JsonMapper.builder()
+                .defaultLocale(Locale.ENGLISH)
                 .addModule(new JavaTimeModule());
     }
 

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
@@ -26,6 +27,11 @@ public class ZonedDateTimeDeserTest extends ModuleTestBase
 {
     private final ObjectReader READER = newMapper().readerFor(ZonedDateTime.class);
     private final TypeReference<Map<String, ZonedDateTime>> MAP_TYPE_REF = new TypeReference<Map<String, ZonedDateTime>>() { };
+
+    static class WrapperWithFeatures {
+        @JsonFormat(without = JsonFormat.Feature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+        public ZonedDateTime value;
+    }
 
     @Test
     public void testDeserializationAsString01() throws Exception
@@ -100,6 +106,17 @@ public class ZonedDateTimeDeserTest extends ModuleTestBase
     			.configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true)
     			.readerFor(ZonedDateTime.class).readValue(a2q(json));
     	assertNull(value);
+    }
+
+    @Test
+    public void testDeserializationWithZonePreserved() throws Throwable
+    {
+        WrapperWithFeatures wrapper = newMapper()
+                .readerFor(WrapperWithFeatures.class)
+                .readValue("{\"value\":\"2000-01-01T12:00+01:00\"}");
+        assertEquals("Timezone should be preserved.",
+                ZonedDateTime.of(2000, 1, 1, 12, 0, 0 ,0, ZoneOffset.ofHours(1)),
+                wrapper.value);
     }
 
     /*

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -106,7 +107,7 @@ public class ZonedDateTimeSerTest
     public void testSerializationAsTimestamp01NegativeSecondsWithDefaults() throws Exception
     {
         // test for Issue #69 using default mapper config
-        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm:ss.SSS zzz");
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm:ss.SSS zzz", Locale.ENGLISH);
         ZonedDateTime original = ZonedDateTime.parse("Apr 13 1969 05:05:38.599 UTC", dtf);
         String serialized = MAPPER.writeValueAsString(original);
         ZonedDateTime deserialized = MAPPER.readValue(serialized, ZonedDateTime.class);


### PR DESCRIPTION
…verride if there were no other options defined on it. Added a fixed English `Locale` to tests b/c they were not passing in non-English environment.

**CLA has been signed**