### PR TITLE
Added a regex checker and fixer for offsets without colons for ZDateTime and OSDateTime

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -65,7 +65,7 @@ public class InstantDeserializer<T extends Temporal>
      *
      * @since 2.13
      */
-    private static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("[+-][0-9]{4}");
+    private static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("(?<!^)[+-][0-9]{4}");
 
     public static final InstantDeserializer<Instant> INSTANT = new InstantDeserializer<>(
             Instant.class, DateTimeFormatter.ISO_INSTANT,

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -65,7 +65,7 @@ public class InstantDeserializer<T extends Temporal>
      *
      * @since 2.13
      */
-    protected static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("(?<!^)[+-][0-9]{4}");
+    protected static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("[+-][0-9]{4}(?=\\[|$)");
 
     public static final InstantDeserializer<Instant> INSTANT = new InstantDeserializer<>(
             Instant.class, DateTimeFormatter.ISO_INSTANT,

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -38,6 +38,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -58,6 +59,13 @@ public class InstantDeserializer<T extends Temporal>
      * @since 2.9.0
      */
     private static final Pattern ISO8601_UTC_ZERO_OFFSET_SUFFIX_REGEX = Pattern.compile("\\+00:?(00)?$");
+
+    /**
+     * Constants used to check if ISO 8601 time string is colonless. See [jackson-modules-java8#131]
+     *
+     * @since 2.13
+     */
+    private static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("[+-][0-9]{4}");
 
     public static final InstantDeserializer<Instant> INSTANT = new InstantDeserializer<>(
             Instant.class, DateTimeFormatter.ISO_INSTANT,
@@ -277,6 +285,16 @@ public class InstantDeserializer<T extends Temporal>
             string = replaceZeroOffsetAsZIfNecessary(string);
         }
 
+        // For some reason DateTimeFormatter.ISO_INSTANT only supports UTC ISO 8601 strings, so it have to be excluded
+        if (_formatter == DateTimeFormatter.ISO_OFFSET_DATE_TIME ||
+            _formatter == DateTimeFormatter.ISO_ZONED_DATE_TIME) {
+
+            // 21-March-2021, Oeystein: Work-around for supporting iso-8601 time offsets that are
+            // specified without a colon as OffsetTime.parse() only support ones with.
+            // https://github.com/FasterXML/jackson-modules-java8/issues/131
+            string = addInColonToOffsetIfMissing(string);
+        }
+
         T value;
         try {
             TemporalAccessor acc = _formatter.parse(string);
@@ -318,6 +336,20 @@ public class InstantDeserializer<T extends Temporal>
     {
         if (replaceZeroOffsetAsZ) {
             return ISO8601_UTC_ZERO_OFFSET_SUFFIX_REGEX.matcher(text).replaceFirst("Z");
+        }
+
+        return text;
+    }
+
+    private String addInColonToOffsetIfMissing(String text)
+    {
+        Matcher matcher = ISO8601_COLONLESS_OFFSET_REGEX.matcher(text);
+
+        if (matcher.find()){
+            StringBuilder sb = new StringBuilder(matcher.group(0));
+            sb.insert(3, ":");
+
+            return matcher.replaceFirst(sb.toString());
         }
 
         return text;

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -65,7 +65,7 @@ public class InstantDeserializer<T extends Temporal>
      *
      * @since 2.13
      */
-    private static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("(?<!^)[+-][0-9]{4}");
+    protected static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("(?<!^)[+-][0-9]{4}");
 
     public static final InstantDeserializer<Instant> INSTANT = new InstantDeserializer<>(
             Instant.class, DateTimeFormatter.ISO_INSTANT,
@@ -289,8 +289,9 @@ public class InstantDeserializer<T extends Temporal>
         if (_formatter == DateTimeFormatter.ISO_OFFSET_DATE_TIME ||
             _formatter == DateTimeFormatter.ISO_ZONED_DATE_TIME) {
 
-            // 21-March-2021, Oeystein: Work-around for supporting iso-8601 time offsets that are
-            // specified without a colon as OffsetTime.parse() only support ones with.
+            // 21-March-2021, Oeystein: Work-around to support basic iso 8601 format (colon-less).
+            // As per JSR-310; Only extended 8601 formats (with colon) are supported for
+            // ZonedDateTime.parse() and OffsetDateTime.parse().
             // https://github.com/FasterXML/jackson-modules-java8/issues/131
             string = addInColonToOffsetIfMissing(string);
         }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
+import static com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer.ISO8601_COLONLESS_OFFSET_REGEX;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
 
@@ -521,5 +523,41 @@ public class InstantDeserTest extends ModuleTestBase
 
         String valueFromEmptyStr = mapper.writeValueAsString(asMap(key, ""));
         objectReader.readValue(valueFromEmptyStr);
+    }
+    
+    /*
+    /************************************************************************
+    /* Tests for InstantDeserializer.ISO8601_COLONLESS_OFFSET_REGEX
+    /************************************************************************
+    */
+    @Test
+    public void testISO8601ColonlessRegexFindsOffset() {
+        Matcher matcher = ISO8601_COLONLESS_OFFSET_REGEX.matcher("2000-01-01T12:00+0100");
+
+        assertTrue("Matcher finds +0100 as an colonless offset", matcher.find());
+        assertEquals("Matcher groups +0100 as an colonless offset", matcher.group(), "+0100");
+    }
+
+    @Test
+    public void testISO8601ColonlessRegexFindsOffsetWithTZ() {
+        Matcher matcher = ISO8601_COLONLESS_OFFSET_REGEX.matcher("2000-01-01T12:00+0100[Europe/Paris]");
+
+        assertTrue("Matcher finds +0100 as an colonless offset", matcher.find());
+        assertEquals("Matcher groups +0100 as an colonless offset", matcher.group(), "+0100");
+    }
+
+    @Test
+    public void testISO8601ColonlessRegexDoesNotAffectNegativeYears() {
+        Matcher matcher = ISO8601_COLONLESS_OFFSET_REGEX.matcher("-2000-01-01T12:00+01:00[Europe/Paris]");
+
+        assertFalse("Matcher does not find -2000 (years) as an offset without colon", matcher.find());
+    }
+
+    @Test
+    public void testISO8601ColonlessRegexDoesNotAffectNegativeYearsWithColonless() {
+        Matcher matcher = ISO8601_COLONLESS_OFFSET_REGEX.matcher("-2000-01-01T12:00+0100[Europe/Paris]");
+
+        assertTrue("Matcher finds +0100 as an colonless offset", matcher.find());
+        assertEquals("Matcher groups +0100 as an colonless offset", matcher.group(), "+0100");
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -344,6 +344,22 @@ public class OffsetDateTimeDeserTest
     }
 
     @Test
+    public void testDeserializationAsString01WithTimeZoneColonless() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(0L), Z1);
+        ObjectMapper m = newMapper()
+            .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+
+        String sDate = offsetWithoutColon(FORMATTER.format(date));
+
+        OffsetDateTime value = m.readValue('"' + sDate + '"', OffsetDateTime.class);
+
+        assertNotNull("The value should not be null.", value);
+        assertIsEqual(date, value);
+        assertEquals("The time zone is not correct.", getOffset(value, Z1), value.getOffset());
+    }
+
+    @Test
     public void testDeserializationAsString02WithoutTimeZone() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
@@ -385,6 +401,22 @@ public class OffsetDateTimeDeserTest
     }
 
     @Test
+    public void testDeserializationAsString02WithTimeZoneColonless() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochSecond(123456789L, 183917322), Z2);
+        ObjectMapper m = newMapper()
+            .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+
+        String sDate = offsetWithoutColon(FORMATTER.format(date));
+
+        OffsetDateTime value = m.readValue('"' + sDate + '"', OffsetDateTime.class);
+
+        assertNotNull("The value should not be null.", value);
+        assertIsEqual(date, value);
+        assertEquals("The time zone is not correct.", getOffset(value, Z2), value.getOffset());
+    }
+
+    @Test
     public void testDeserializationAsString03WithoutTimeZone() throws Exception
     {
         OffsetDateTime date = OffsetDateTime.now(Z3);
@@ -419,6 +451,23 @@ public class OffsetDateTimeDeserTest
             .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
             .setTimeZone(TimeZone.getDefault());
         OffsetDateTime value = m.readValue('"' + FORMATTER.format(date) + '"', OffsetDateTime.class);
+
+        assertNotNull("The value should not be null.", value);
+        assertIsEqual(date, value);
+        assertEquals("The time zone is not correct.", getOffset(value, Z3), value.getOffset());
+    }
+
+
+    @Test
+    public void testDeserializationAsString03WithTimeZoneColonless() throws Exception
+    {
+        OffsetDateTime date = OffsetDateTime.now(Z3);
+        ObjectMapper m = newMapper()
+            .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+
+        String sDate = offsetWithoutColon(FORMATTER.format(date));
+
+        OffsetDateTime value = m.readValue('"' + sDate + '"', OffsetDateTime.class);
 
         assertNotNull("The value should not be null.", value);
         assertIsEqual(date, value);
@@ -708,5 +757,9 @@ public class OffsetDateTimeDeserTest
     private static ZoneOffset getOffset(OffsetDateTime date, ZoneId zone)
     {
         return zone.getRules().getOffset(date.toLocalDateTime());
+    }
+
+    private static String offsetWithoutColon(String string){
+        return new StringBuilder(string).deleteCharAt(string.lastIndexOf(":")).toString();
     }
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
@@ -161,6 +161,36 @@ public class ZonedDateTimeDeserTest extends ModuleTestBase
         objectReader.readValue(valueFromEmptyStr);
     }
 
+    /*
+    /**********************************************************
+    / Tests for Iso 8601s ZonedDateTimes that are colonless
+    /**********************************************************
+    */
+
+    @Test
+    public void testDeserializationWithoutColonInOffset() throws Throwable
+    {
+        WrapperWithFeatures wrapper = newMapper()
+                .readerFor(WrapperWithFeatures.class)
+                .readValue("{\"value\":\"2000-01-01T12:00+0100\"}");
+
+        assertEquals("Value parses as if it were with colon",
+                ZonedDateTime.of(2000, 1, 1, 12, 0, 0 ,0, ZoneOffset.ofHours(1)),
+                wrapper.value);
+    }
+
+    @Test
+    public void testDeserializationWithoutColonInTimeZoneWithTZDB() throws Throwable
+    {
+        WrapperWithFeatures wrapper = newMapper()
+                .readerFor(WrapperWithFeatures.class)
+                .readValue("{\"value\":\"2000-01-01T12:00+0100[Europe/Paris]\"}");
+        assertEquals("Timezone should be preserved.",
+                ZonedDateTime.of(2000, 1, 1, 12, 0, 0 ,0, ZoneId.of("Europe/Paris")),
+                wrapper.value);
+    }
+
+
     private void expectFailure(String json) throws Throwable {
         try {
             READER.readValue(a2q(json));


### PR DESCRIPTION
## WHY
See issue #131 for details 

Colonless offsets for ISO 8601s strings a common way of representing DateTimes with offsets. Unfortunately ZonedDateTime.parse(string) and OffsetDateTime.parse(string) does not support this, breaking jackson compatibility. 

## HOW
Uses a regex to check for offsets without colons, and if found - adds in a colon to make it compatible with ZonedDateTime.parse() and OffsetDateTime.parse()