### PR TITLE
Simplify handling of `LocalDate` value with invalid trailing time-portion

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -155,7 +155,8 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                 // JavaScript by default includes time in JSON serialized Dates (UTC/ISO instant format).
                 if (string.length() > 10 && string.charAt(10) == 'T') {
                    if (string.endsWith("Z")) {
-                       return LocalDateTime.ofInstant(Instant.parse(string), ZoneOffset.UTC).toLocalDate();
+                       return LocalDate.parse(string.substring(0, string.length() - 1),
+                               DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                    } else {
                        return LocalDate.parse(string, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                    }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
@@ -83,6 +83,15 @@ public class LocalDateDeserTest extends ModuleTestBase
         public StrictWrapperWithYearWithoutEra(LocalDate v) { value = v; }
     }
 
+    static class StrictWrapperWithFormat {
+        @JsonFormat(pattern="yyyy-MM-dd",
+                lenient = OptBoolean.FALSE)
+        public LocalDate value;
+
+        public StrictWrapperWithFormat() { }
+        public StrictWrapperWithFormat(LocalDate v) { value = v; }
+    }
+
     /*
     /**********************************************************
     /* Deserialization from Int array representation
@@ -324,6 +333,21 @@ public class LocalDateDeserTest extends ModuleTestBase
         assertEquals(28, date.getDayOfMonth());
     }
 
+    @Test
+    public void testStrictCustomFormat() throws Exception
+    {
+        try {
+            /*StrictWrapperWithFormat w = */ MAPPER.readValue(
+                "{\"value\":\"2019-11-30\"}",
+                StrictWrapperWithFormat.class);
+            fail("Should not pass");
+        } catch (InvalidFormatException e) {
+            // 25-Mar-2021, tatu: Really bad exception message we got... but
+            //   it is what it is
+            verifyException(e, "Cannot deserialize value of type `java.time.LocalDate` from String");
+            verifyException(e, "\"2019-11-30\"");
+        }
+    }
 
     /*
     /**********************************************************
@@ -402,7 +426,9 @@ public class LocalDateDeserTest extends ModuleTestBase
     @Test
     public void testDeserializationCaseInsensitiveEnabled() throws Throwable
     {
-        ObjectMapper mapper = newMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES, true);
+        ObjectMapper mapper = mapperBuilder()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
+                .build();
         mapper.configOverride(LocalDate.class).setFormat(JsonFormat.Value.forPattern("dd-MMM-yyyy"));
         ObjectReader reader = mapper.readerFor(LocalDate.class);
         String[] jsons = new String[] {"'01-Jan-2000'","'01-JAN-2000'", "'01-jan-2000'"};
@@ -414,7 +440,9 @@ public class LocalDateDeserTest extends ModuleTestBase
     @Test
     public void testDeserializationCaseInsensitiveDisabled() throws Throwable
     {
-        ObjectMapper mapper = newMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES, false);
+        ObjectMapper mapper = mapperBuilder()
+                .disable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
+                .build();
         mapper.configOverride(LocalDate.class).setFormat(JsonFormat.Value.forPattern("dd-MMM-yyyy"));
         ObjectReader reader = mapper.readerFor(LocalDate.class);
         expectSuccess(reader, LocalDate.of(2000, Month.JANUARY, 1), "'01-Jan-2000'");
@@ -423,7 +451,9 @@ public class LocalDateDeserTest extends ModuleTestBase
     @Test
     public void testDeserializationCaseInsensitiveDisabled_InvalidDate() throws Throwable
     {
-        ObjectMapper mapper = newMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES, false);
+        ObjectMapper mapper = mapperBuilder()
+                .disable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
+                .build();
         mapper.configOverride(LocalDate.class).setFormat(JsonFormat.Value.forPattern("dd-MMM-yyyy"));
         ObjectReader reader = mapper.readerFor(LocalDate.class);
         String[] jsons = new String[] {"'01-JAN-2000'", "'01-jan-2000'"};

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/failing/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/failing/LocalDateDeserTest.java
@@ -12,18 +12,18 @@ import java.time.LocalDate;
 public class LocalDateDeserTest extends ModuleTestBase {
     private final ObjectMapper MAPPER = newMapper();
 
-    final static class StrictWrapper {
+    static class StrictWrapperWithFormat {
         @JsonFormat(pattern="yyyy-MM-dd",
                 lenient = OptBoolean.FALSE)
         public LocalDate value;
 
-        public StrictWrapper() { }
-        public StrictWrapper(LocalDate v) { value = v; }
+        public StrictWrapperWithFormat() { }
+        public StrictWrapperWithFormat(LocalDate v) { value = v; }
     }
-
     @Test(expected = InvalidFormatException.class)
     public void testStrictCustomFormat() throws Exception
     {
-        /*StrictWrapper w =*/ MAPPER.readValue("{\"value\":\"2019-11-30\"}", StrictWrapper.class);
+        /*StrictWrapper w =*/ MAPPER.readValue("{\"value\":\"2019-11-30\"}",
+                StrictWrapperWithFormat.class);
     }
 }


### PR DESCRIPTION
As per title: test change just cleaning up, but for `LocalDate`, avoid unnecessary handling of timezone.