### PR TITLE
Fix broken links to Serialization / Deserialization

### DIFF
--- a/datetime/README.md
+++ b/datetime/README.md
@@ -3,7 +3,7 @@ Datatype module to make Jackson recognize Java 8 Date & Time API data types (JSR
 ## Summary
 
 Most [JSR-310](https://jcp.org/en/jsr/detail?id=310) types are serialized as numbers (integers or decimals as appropriate) if the
-[`SerializationFeature#WRITE_DATES_AS_TIMESTAMPS`](http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/com/fasterxml/jackson/databind/SerializationFeature.html#WRITE_DATES_AS_TIMESTAMPS)
+[`SerializationFeature.WRITE_DATES_AS_TIMESTAMPS`](https://github.com/FasterXML/jackson-databind/wiki/Serialization-features#datatype-specific-serialization)
 feature is enabled, and otherwise are serialized in standard [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601)
 string representation. ISO-8601 specifies formats for representing offset dates and times, zoned dates and times,
 local dates and times, periods, durations, zones, and more. All JSR-310 types have built-in translation to and from
@@ -22,9 +22,9 @@ For string representation default formats for deserialization are:
 |[`YearMonth`](https://docs.oracle.com/javase/8/docs/api/java/time/YearMonth.html)|[`DateTimeFormatter.ofPattern("uuuu-MM")`](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ofPattern-java.lang.String-)|
 
 Granularity of timestamps is controlled through the companion features
-[`SerializationFeature#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS`](http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/com/fasterxml/jackson/databind/SerializationFeature.html#WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+[`SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS`](https://github.com/FasterXML/jackson-databind/wiki/Serialization-features#datatype-specific-serialization)
 and
-[`DeserializationFeature#READ_DATE_TIMESTAMPS_AS_NANOSECONDS`](http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/com/fasterxml/jackson/databind/DeserializationFeature.html#READ_DATE_TIMESTAMPS_AS_NANOSECONDS).
+[`DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS`](https://github.com/FasterXML/jackson-databind/wiki/Deserialization-Features#value-conversions-coercion).
 For serialization, timestamps are written as fractional numbers (decimals), where the number is seconds and the decimal
 is fractional seconds, if `WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS` is enabled (it is by default), with resolution as fine
 as nanoseconds depending on the underlying JDK implementation. If `WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS` is disabled,


### PR DESCRIPTION
Fix for #226. This fixes the broken links using Github's automatic anchors, however it only links to the header, should it be more granular?