### PR TITLE
optimize help ignore parameter name parse

### DIFF
--- a/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/JsonParamNameIgnore.java
+++ b/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/JsonParamNameIgnore.java
@@ -1,0 +1,23 @@
+package com.fasterxml.jackson.module.paramnames;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Using this annotation to prevent {@link ParameterNamesAnnotationIntrospector} parse parameter name.
+ * When it's on method parameter, only annotated parameter ignored. All parameters will be ignored when it's on a method.
+ *
+ * @author Brozen Lau
+ */
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotation
+public @interface JsonParamNameIgnore {
+
+    boolean value() default true;
+
+}

--- a/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
+++ b/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospector.java
@@ -37,10 +37,14 @@ public class ParameterNamesAnnotationIntrospector extends NopAnnotationIntrospec
     }
 
     private String findParameterName(AnnotatedParameter annotatedParameter) {
+        AnnotatedWithParams owner = annotatedParameter.getOwner();
+        if (isParameterIgnored(annotatedParameter) || isParameterIgnored(owner)) {
+            return null;
+        }
 
         Parameter[] params;
         try {
-            params = getParameters(annotatedParameter.getOwner());
+            params = getParameters(owner);
         } catch (MalformedParametersException e) {
             return null;
         }
@@ -58,6 +62,12 @@ public class ParameterNamesAnnotationIntrospector extends NopAnnotationIntrospec
         }
 
         return null;
+    }
+
+
+    private boolean isParameterIgnored(AnnotatedMember member) {
+        JsonParamNameIgnore parameterIgnore = member.getAnnotation(JsonParamNameIgnore.class);
+        return parameterIgnore != null && parameterIgnore.value();
     }
 
     /*

--- a/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesModule.java
+++ b/parameter-names/src/main/java/com/fasterxml/jackson/module/paramnames/ParameterNamesModule.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.paramnames;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class ParameterNamesModule extends SimpleModule


### PR DESCRIPTION
add an annotation `@JsonParamNameIgnore` to help ignore parameter name parse. And help resolve issue [#234](https://github.com/FasterXML/jackson-modules-java8/issues/234)