### PR TITLE
LocalDateDeserializer should reflect coercionConfig

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 
 /**
  * Deserializer for Java 8 temporal {@link LocalDate}s.
@@ -127,6 +129,11 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
         }
         // 06-Jan-2018, tatu: Is this actually safe? Do users expect such coercion?
         if (parser.hasToken(JsonToken.VALUE_NUMBER_INT)) {
+            CoercionAction act = context.findCoercionAction(logicalType(), _valueClass,
+                    CoercionInputShape.Integer);
+            _checkCoercionFail(context, act, handledType(), parser.getLongValue(),
+                    "Integer value (" + parser.getLongValue() + ")");
+
             // issue 58 - also check for NUMBER_INT, which needs to be specified when serializing.
             if (_shape == JsonFormat.Shape.NUMBER_INT || isLenient()) {
                 return LocalDate.ofEpochDay(parser.getLongValue());


### PR DESCRIPTION
Currently LocalDateDeserializer does not take into account the following configuration:
`setCoercion(CoercionInputShape.Integer, CoercionAction.Fail);`