### PR TITLE
minor tweak to pass the JsonParser instance 

### DIFF
--- a/datatypes/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalDoubleDeserializer.java
+++ b/datatypes/src/main/java/com/fasterxml/jackson/datatype/jdk8/OptionalDoubleDeserializer.java
@@ -48,7 +48,7 @@ class OptionalDoubleDeserializer extends BaseScalarOptionalDeserializer<Optional
             // 21-Jun-2020, tatu: Should this also accept "textual null" similar
             //   to regular Doubles?
             text = text.trim();
-            return OptionalDouble.of(_parseDoublePrimitive(ctxt, text));
+            return OptionalDouble.of(_parseDoublePrimitive(p, ctxt, text));
         case JsonTokenId.ID_NUMBER_INT: // coercion here should be fine
             return OptionalDouble.of(p.getDoubleValue());
         case JsonTokenId.ID_NULL:


### PR DESCRIPTION
Passing JsonParser instance allows features to be checked - the fast double parser feature being one that could be set