### PR TITLE
Change InstantSerializerBase to format dates in the same way as DateTimeSerializerBase

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonIntegerFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonNumberFormatVisitor;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
 import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
 
 /**
@@ -127,6 +128,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
             JsonIntegerFormatVisitor v2 = visitor.expectIntegerFormat(typeHint);
             if (v2 != null) {
                 v2.numberType(NumberType.LONG);
+                v2.format(JsonValueFormat.UTC_MILLISEC);
             }
         }
     }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/misc/DateTimeSchemasTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/misc/DateTimeSchemasTest.java
@@ -1,6 +1,8 @@
 package com.fasterxml.jackson.datatype.jsr310.misc;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 import org.junit.Assert;
@@ -185,32 +187,11 @@ public class DateTimeSchemasTest extends ModuleTestBase
         Assert.assertEquals(1, properties.size());
         _verifyBigDecimalType(properties.get(""));
 
-        // but becomes date/time
-        wrapper = new VisitorWrapper(null, "", new HashMap<String, String>());
-        MAPPER.writer().without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .acceptJsonFormatVisitor(ZonedDateTime.class, wrapper);
-        properties = wrapper.getTraversedProperties();
-        _verifyDateTimeType(properties.get(""));
-    }
-
-
-    @Test
-    public void testInstantSchema() throws Exception
-    {
-        VisitorWrapper wrapper = new VisitorWrapper(null, "", new HashMap<String, String>());
-        MAPPER.writer().acceptJsonFormatVisitor(Instant.class, wrapper);
-        Map<String, String> properties = wrapper.getTraversedProperties();
-
-        // By default, serialized as an int array, so:
-        Assert.assertEquals(1, properties.size());
-        _verifyBigDecimalType(properties.get(""));
-
-
-        // but becomes date/time
+        // but becomes long
         wrapper = new VisitorWrapper(null, "", new HashMap<String, String>());
         MAPPER.writer()
                 .without(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
-                .acceptJsonFormatVisitor(Instant.class, wrapper);
+                .acceptJsonFormatVisitor(ZonedDateTime.class, wrapper);
         properties = wrapper.getTraversedProperties();
         _verifyLongType(properties.get("numberType"));
         _verifyLongFormat(properties.get("format"));
@@ -218,7 +199,7 @@ public class DateTimeSchemasTest extends ModuleTestBase
         // but becomes date/time
         wrapper = new VisitorWrapper(null, "", new HashMap<String, String>());
         MAPPER.writer().without(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .acceptJsonFormatVisitor(Instant.class, wrapper);
+            .acceptJsonFormatVisitor(ZonedDateTime.class, wrapper);
         properties = wrapper.getTraversedProperties();
         _verifyDateTimeType(properties.get(""));
     }


### PR DESCRIPTION
This fix an issue I have with jsonSchema where the schema generated for Dates differ from the Java Time ones.

I believe this also may affect other applications that relies on jackson formats.