### PR TITLE
Optimize InstantDeserializer replaceZeroOffsetAsZIfNecessary

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -344,13 +344,19 @@ public class InstantDeserializer<T extends Temporal>
         }
         int maybeOffsetIndex = plusIndex + 1;
         int remaining = text.length() - maybeOffsetIndex;
-        if (remaining < 2 || remaining == 3 || remaining > 5) {
-            return text;
-        }
-
-        String maybeOffset = text.substring(maybeOffsetIndex);
-        if ("00".equals(maybeOffset) || "0000".equals(maybeOffset) || "00:00".equals(maybeOffset)) {
-            return text.substring(0, plusIndex) + 'Z';
+        switch (remaining) {
+            case 2:
+                return text.regionMatches(maybeOffsetIndex, "00", 0, remaining)
+                        ? text.substring(0, plusIndex) + 'Z'
+                        : text;
+            case 4:
+                return text.regionMatches(maybeOffsetIndex, "0000", 0, remaining)
+                        ? text.substring(0, plusIndex) + 'Z'
+                        : text;
+            case 5:
+                return text.regionMatches(maybeOffsetIndex, "00:00", 0, remaining)
+                        ? text.substring(0, plusIndex) + 'Z'
+                        : text;
         }
         return text;
     }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 import static com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer.ISO8601_COLONLESS_OFFSET_REGEX;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
 
 public class InstantDeserTest extends ModuleTestBase
 {
@@ -434,8 +435,41 @@ public class InstantDeserTest extends ModuleTestBase
         assertEquals("The value is not correct.", date, result);
     }
 
+    @Test
+    public void testDeserializationFromStringWithZeroZoneOffset04() throws Exception {
+        assumeInstantCanParseOffsets();
+        Instant date = Instant.now();
+        String json = formatWithZeroZoneOffset(date, "+00:30");
+        Instant result = READER.readValue(json);
+        assertNotEquals("The value is not correct.", date, result);
+    }
+
+    @Test
+    public void testDeserializationFromStringWithZeroZoneOffset05() throws Exception {
+        assumeInstantCanParseOffsets();
+        Instant date = Instant.now();
+        String json = formatWithZeroZoneOffset(date, "+01:30");
+        Instant result = READER.readValue(json);
+        assertNotEquals("The value is not correct.", date, result);
+    }
+
+    @Test
+    public void testDeserializationFromStringWithZeroZoneOffset06() throws Exception {
+        assumeInstantCanParseOffsets();
+        Instant date = Instant.now();
+        String json = formatWithZeroZoneOffset(date, "-00:00");
+        Instant result = READER.readValue(json);
+        assertEquals("The value is not correct.", date, result);
+    }
+
     private String formatWithZeroZoneOffset(Instant date, String offset){
         return '"' + FORMATTER.format(date).replaceFirst("Z$", offset) + '"';
+    }
+
+    private static void assumeInstantCanParseOffsets() {
+        // DateTimeFormatter.ISO_INSTANT didn't handle offsets until JDK 12+.
+        // This was added by https://bugs.openjdk.org/browse/JDK-8166138
+        assumeTrue(System.getProperty("java.specification.version").compareTo("12") > 0);
     }
 
     /*


### PR DESCRIPTION
While reviewing some JFRs from some services that heavily use Jackson for deserializing timestamps, I noticed that `com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer.replaceZeroOffsetAsZIfNecessary(String)` was allocating a lot of `int[]` from its use of `java.util.regex.Pattern.matcher(CharSequence)` to determine whether an input String is a zero offset and if so replace it with `Z`.

![image](https://user-images.githubusercontent.com/54594/217441155-375e38a7-d252-48b3-a4a7-0435461f4728.png)


I would like to propose an alternative implementation to avoid expensive regex matcher allocations when replacing zero offset with 'Z'.

Using a [JMH benchmark with a variety of generated timestamps](https://gist.github.com/schlosna/abe63391e890a672a88330db13989db8) I see the following results on x64 (~7x speedup) and aarch64 (~2.5x speedup):

#### OpenJDK 17.0.6 on x64 Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
```
Benchmark                           Mode  Cnt    Score   Error  Units
InstantDeserializerBenchmark.index  avgt    5   19.543 ± 1.384  ns/op
InstantDeserializerBenchmark.regex  avgt    5  155.081 ± 3.234  ns/op
```


#### OpenJDK 17.0.6 on aarch64 Apple M1 Pro
```
Benchmark                           Mode  Cnt   Score   Error  Units
InstantDeserializerBenchmark.index  avgt    5  16.855 ± 0.537  ns/op
InstantDeserializerBenchmark.regex  avgt    5  58.155 ± 1.444  ns/op
```