### PR TITLE
Add feature toggle to read numeric strings as numeric timestamps

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
@@ -20,14 +20,16 @@ public enum JavaTimeFeature implements JacksonFeature
     NORMALIZE_DESERIALIZED_ZONE_ID(true),
 
     /**
-     * Feature that controls whether numeric strings may be interpreted as numeric
-     * timestamps (enabled) or not (disabled), in addition to an explicitly
-     * defined pattern.
+     * Feature that controls whether stringified numbers (Strings that without
+     * quotes would be legal JSON Numbers) may be interpreted as
+     * timestamps (enabled) or not (disabled), in case where there is an
+     * explicitly defined pattern ({@code DateTimeFormatter}) for value.
      * <p>
-     * Note that when a pattern is not explicitly defined numeric strings are
-     * interpreted as a numeric timestamp.
+     * Note that when the default pattern is used (no custom pattern defined),
+     * stringified numbers are always accepted as timestamps regardless of
+     * this feature.
      */
-    ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS(false)
+    ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS(false)
     ;
 
   /**

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
@@ -20,14 +20,14 @@ public enum JavaTimeFeature implements JacksonFeature
     NORMALIZE_DESERIALIZED_ZONE_ID(true),
 
     /**
-     * Feature that controls whether numeric strings are interpreted as numeric
-     * timestamps (enabled) nor not (disabled) in addition to an explicitly
+     * Feature that controls whether numeric strings may be interpreted as numeric
+     * timestamps (enabled) or not (disabled), in addition to an explicitly
      * defined pattern.
      * <p>
      * Note that when a pattern is not explicitly defined numeric strings are
      * interpreted as a numeric timestamp.
      */
-    READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP(false);
+    ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS(false);
 
     /**
      * Whether feature is enabled or disabled by default.

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
@@ -17,7 +17,17 @@ public enum JavaTimeFeature implements JacksonFeature
      * Default setting is enabled, for backwards-compatibility with
      * Jackson 2.15.
      */
-    NORMALIZE_DESERIALIZED_ZONE_ID(true);
+    NORMALIZE_DESERIALIZED_ZONE_ID(true),
+
+    /**
+     * Feature that controls whether numeric strings are interpreted as numeric
+     * timestamps (enabled) nor not (disabled) in addition to an explicitly
+     * defined pattern.
+     * <p>
+     * Note that when a pattern is not explicitly defined numeric strings are
+     * interpreted as a numeric timestamp.
+     */
+    READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP(false);
 
     /**
      * Whether feature is enabled or disabled by default.

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -343,10 +343,11 @@ public class InstantDeserializer<T extends Temporal>
             //   handled like "regular" empty (same as pre-2.12)
             return _fromEmptyString(p, ctxt, string);
         }
-        // only check for other parsing modes if we are using default formatter
+        // only check for other parsing modes if we are using default formatter or explicitly asked to
         if (_formatter == DateTimeFormatter.ISO_INSTANT ||
             _formatter == DateTimeFormatter.ISO_OFFSET_DATE_TIME ||
-            _formatter == DateTimeFormatter.ISO_ZONED_DATE_TIME) {
+            _formatter == DateTimeFormatter.ISO_ZONED_DATE_TIME ||
+            ctxt.isEnabled(DeserializationFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP)) {
             // 22-Jan-2016, [datatype-jsr310#16]: Allow quoted numbers too
             int dots = _countPeriods(string);
             if (dots >= 0) { // negative if not simple number

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -57,6 +57,7 @@ public class InstantDeserializer<T extends Temporal>
     private static final long serialVersionUID = 1L;
 
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
+    private final static boolean DEFAULT_READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP = JavaTimeFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP.enabledByDefault();
 
     /**
      * Constants used to check if ISO 8601 time string is colonless. See [jackson-modules-java8#131]
@@ -72,7 +73,8 @@ public class InstantDeserializer<T extends Temporal>
             a -> Instant.ofEpochSecond(a.integer, a.fraction),
             null,
             true, // yes, replace zero offset with Z
-            DEFAULT_NORMALIZE_ZONE_ID 
+            DEFAULT_NORMALIZE_ZONE_ID,
+            DEFAULT_READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP
     );
 
     public static final InstantDeserializer<OffsetDateTime> OFFSET_DATE_TIME = new InstantDeserializer<>(
@@ -82,7 +84,8 @@ public class InstantDeserializer<T extends Temporal>
             a -> OffsetDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId),
             (d, z) -> (d.isEqual(OffsetDateTime.MIN) || d.isEqual(OffsetDateTime.MAX) ? d : d.withOffsetSameInstant(z.getRules().getOffset(d.toLocalDateTime()))),
             true, // yes, replace zero offset with Z
-            DEFAULT_NORMALIZE_ZONE_ID 
+            DEFAULT_NORMALIZE_ZONE_ID,
+            DEFAULT_READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP
     );
 
     public static final InstantDeserializer<ZonedDateTime> ZONED_DATE_TIME = new InstantDeserializer<>(
@@ -92,7 +95,8 @@ public class InstantDeserializer<T extends Temporal>
             a -> ZonedDateTime.ofInstant(Instant.ofEpochSecond(a.integer, a.fraction), a.zoneId),
             ZonedDateTime::withZoneSameInstant,
             false, // keep zero offset and Z separate since zones explicitly supported
-            DEFAULT_NORMALIZE_ZONE_ID 
+            DEFAULT_NORMALIZE_ZONE_ID,
+            DEFAULT_READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP
     );
 
     protected final Function<FromIntegerArguments, T> fromMilliseconds;
@@ -133,6 +137,14 @@ public class InstantDeserializer<T extends Temporal>
      */
     protected final boolean _normalizeZoneId;
 
+    /**
+     * Flag set from
+     * {@link com.fasterxml.jackson.datatype.jsr310.JavaTimeFeature#READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP}
+     * to determine whether numeric strings are interpreted as numeric timestamps
+     * (enabled) nor not (disabled) in addition to an explicitly defined pattern.
+     */
+    protected final boolean _readNumericStringsAsTimestamp;
+
     protected InstantDeserializer(Class<T> supportedType,
             DateTimeFormatter formatter,
             Function<TemporalAccessor, T> parsedToValue,
@@ -140,7 +152,9 @@ public class InstantDeserializer<T extends Temporal>
             Function<FromDecimalArguments, T> fromNanoseconds,
             BiFunction<T, ZoneId, T> adjust,
             boolean replaceZeroOffsetAsZ,
-            boolean normalizeZoneId)
+            boolean normalizeZoneId,
+            boolean readNumericStringsAsTimestamp
+    )
     {
         super(supportedType, formatter);
         this.parsedToValue = parsedToValue;
@@ -151,6 +165,7 @@ public class InstantDeserializer<T extends Temporal>
         this._adjustToContextTZOverride = null;
         this._readTimestampsAsNanosOverride = null;
         _normalizeZoneId = normalizeZoneId;
+        _readNumericStringsAsTimestamp = readNumericStringsAsTimestamp;
     }
 
     @SuppressWarnings("unchecked")
@@ -165,6 +180,7 @@ public class InstantDeserializer<T extends Temporal>
         _adjustToContextTZOverride = base._adjustToContextTZOverride;
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
         _normalizeZoneId = base._normalizeZoneId;
+        _readNumericStringsAsTimestamp = base._readNumericStringsAsTimestamp;
     }
 
     @SuppressWarnings("unchecked")
@@ -179,6 +195,7 @@ public class InstantDeserializer<T extends Temporal>
         _adjustToContextTZOverride = adjustToContextTimezoneOverride;
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
         _normalizeZoneId = base._normalizeZoneId;
+        _readNumericStringsAsTimestamp = base._readNumericStringsAsTimestamp;
     }
 
     @SuppressWarnings("unchecked")
@@ -193,6 +210,7 @@ public class InstantDeserializer<T extends Temporal>
         _adjustToContextTZOverride = base._adjustToContextTZOverride;
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
         _normalizeZoneId = base._normalizeZoneId;
+        _readNumericStringsAsTimestamp = base._readNumericStringsAsTimestamp;
     }
 
     /**
@@ -214,6 +232,7 @@ public class InstantDeserializer<T extends Temporal>
         _adjustToContextTZOverride = adjustToContextTimezoneOverride;
         _readTimestampsAsNanosOverride = readTimestampsAsNanosOverride;
         _normalizeZoneId = base._normalizeZoneId;
+        _readNumericStringsAsTimestamp = base._readNumericStringsAsTimestamp;
     }
 
     /**
@@ -233,7 +252,7 @@ public class InstantDeserializer<T extends Temporal>
         _readTimestampsAsNanosOverride = base._readTimestampsAsNanosOverride;
 
         _normalizeZoneId = features.isEnabled(JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID);
-    
+        _readNumericStringsAsTimestamp = features.isEnabled(JavaTimeFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP);
     }
 
     @Override
@@ -251,7 +270,8 @@ public class InstantDeserializer<T extends Temporal>
 
     // @since 2.16
     public InstantDeserializer<T> withFeatures(JacksonFeatureSet<JavaTimeFeature> features) {
-        if (_normalizeZoneId == features.isEnabled(JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID)) {
+        if (_normalizeZoneId == features.isEnabled(JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID) &&
+            _readNumericStringsAsTimestamp == features.isEnabled(JavaTimeFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP)) {
             return this;
         }
         return new InstantDeserializer<>(this, features);
@@ -347,7 +367,7 @@ public class InstantDeserializer<T extends Temporal>
         if (_formatter == DateTimeFormatter.ISO_INSTANT ||
             _formatter == DateTimeFormatter.ISO_OFFSET_DATE_TIME ||
             _formatter == DateTimeFormatter.ISO_ZONED_DATE_TIME ||
-            ctxt.isEnabled(DeserializationFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP)) {
+            _readNumericStringsAsTimestamp) {
             // 22-Jan-2016, [datatype-jsr310#16]: Allow quoted numbers too
             int dots = _countPeriods(string);
             if (dots >= 0) { // negative if not simple number

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
@@ -937,7 +937,7 @@ public class ZonedDateTimeSerTest
 
         Wrapper result = JsonMapper.builder()
             .addModule(new JavaTimeModule()
-                    .enable(JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS))
+                    .enable(JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS))
             .build()
             .readerFor(Wrapper.class)
             .readValue(input);

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
@@ -32,6 +32,9 @@ import java.time.temporal.Temporal;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -931,8 +934,11 @@ public class ZonedDateTimeSerTest
     {
         String input = a2q("{'value':'3.141592653'}");
 
-        Wrapper result = MAPPER.readerFor(Wrapper.class)
-            .with(DeserializationFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP)
+        Wrapper result = JsonMapper.builder()
+            .addModule(new JavaTimeModule()
+                    .enable(JavaTimeFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP))
+            .build()
+            .readerFor(Wrapper.class)
             .readValue(input);
 
         assertEquals(Instant.ofEpochSecond(3L, 141592653L), result.value.toInstant());

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
@@ -929,6 +929,7 @@ public class ZonedDateTimeSerTest
         assertEquals(input.value.toInstant(), result.value.toInstant());
     }
 
+    // [modules-java#269]
     @Test
     public void testCustomPatternWithNumericTimestamp() throws Exception
     {
@@ -936,7 +937,7 @@ public class ZonedDateTimeSerTest
 
         Wrapper result = JsonMapper.builder()
             .addModule(new JavaTimeModule()
-                    .enable(JavaTimeFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP))
+                    .enable(JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS))
             .build()
             .readerFor(Wrapper.class)
             .readValue(input);

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerTest.java
@@ -927,6 +927,18 @@ public class ZonedDateTimeSerTest
     }
 
     @Test
+    public void testCustomPatternWithNumericTimestamp() throws Exception
+    {
+        String input = a2q("{'value':'3.141592653'}");
+
+        Wrapper result = MAPPER.readerFor(Wrapper.class)
+            .with(DeserializationFeature.READ_NUMERIC_STRINGS_AS_DATE_TIMESTAMP)
+            .readValue(input);
+
+        assertEquals(Instant.ofEpochSecond(3L, 141592653L), result.value.toInstant());
+    }
+
+    @Test
     public void testNumericCustomPatternWithAnnotations() throws Exception
     {
         ZonedDateTime inputValue = ZonedDateTime.ofInstant(Instant.ofEpochSecond(0L), UTC);

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -179,3 +179,9 @@ Raman Babich (raman-babich@github)
  * Contributed fix for #272: `JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS`
     not respected when deserialising `Instant`s
   (2.16.0)
+
+M.P. Korstanje (mpkorstanje@github)
+
+ * Contributed #263: Add `JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS` to allow parsing
+   quoted numbers when using a custom DateTimeFormatter
+  (2.16.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,14 +8,20 @@ Modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+Not yet released
+
+#263: Add `JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS` to allow parsing
+  quoted numbers when using a custom DateTimeFormatter
+ (contributed by M.P. Korstanje)
+#281: (datetime) Add `JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID` to allow
+  disabling ZoneId normalization on deserialization
+ (requested by @indyana)
+
 2.16.0-rc1 (20-Oct-2023)
 
 #272: (datetime) `JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS`
   not respected when deserialising `Instant`s
  (fix contributed by Raman B)
-#281: (datetime) Add `JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID` to allow
-  disabling ZoneId normalization on deserialization
- (requested by @indyana)
 
 2.15.3 (12-Oct-2023)
 2.15.2 (30-May-2023)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -11,7 +11,7 @@ Modules:
 Not yet released
 
 #263: Add `JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS` to allow parsing
-  quoted numbers when using a custom DateTimeFormatter
+  quoted numbers when using a custom pattern (DateTimeFormatter)
  (contributed by M.P. Korstanje)
 #281: (datetime) Add `JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID` to allow
   disabling ZoneId normalization on deserialization


### PR DESCRIPTION
There is an apparent inconsistency in the way Jackson de-serializes numbers that are shaped as a string into an instant.

 * When not providing a custom date format, quoted numbers are treated as epoch milis/nanos
 * When not providing a custom date, quoted numbers are assumed to be handled by the pattern.

There is however no way to construct a pattern that handles both ISO dates and epoch milis/nanos. This feature toggle allow numeric strings to be read as numeric timestamps.

Fixes: https://github.com/FasterXML/jackson-modules-java8/issues/263.

This PR is paired with https://github.com/FasterXML/jackson-databind/pull/3830.