### PR TITLE
#286: Get the pre 2.16 constructor of InstantDeserializer back

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -176,6 +176,24 @@ public class InstantDeserializer<T extends Temporal>
         _alwaysAllowStringifiedDateTimestamps = readNumericStringsAsTimestamp;
     }
 
+    /**
+     * @deprecated Since 2.16, use {@link #InstantDeserializer(Class,DateTimeFormatter,
+     * Function,Function,Function,BiFunction,boolean,boolean,boolean)} instead.
+     */
+    @Deprecated()
+    protected InstantDeserializer(Class<T> supportedType,
+                                  DateTimeFormatter formatter,
+                                  Function<TemporalAccessor, T> parsedToValue,
+                                  Function<FromIntegerArguments, T> fromMilliseconds,
+                                  Function<FromDecimalArguments, T> fromNanoseconds,
+                                  BiFunction<T, ZoneId, T> adjust,
+                                  boolean replaceZeroOffsetAsZ
+
+    ) {
+        this(supportedType, formatter, parsedToValue, fromMilliseconds, fromNanoseconds, adjust, replaceZeroOffsetAsZ,
+                DEFAULT_NORMALIZE_ZONE_ID, DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS);
+    }
+
     @SuppressWarnings("unchecked")
     protected InstantDeserializer(InstantDeserializer<T> base, DateTimeFormatter f)
     {


### PR DESCRIPTION
Fixes #286 

I just added the old constructor back, delegating to the new one with defaults as suggested. You might have some input on the deprecation message. 

I didn't add any tests, let me know if that's needed (not really sure what to test in that case..?). 

The PR is against 2.17, not sure if it should be against 2.16?