### PR TITLE
Fix #286; add back InstantDeserializer constructor from 2.15, deprecated

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -153,6 +153,9 @@ public class InstantDeserializer<T extends Temporal>
      */
     protected final boolean _alwaysAllowStringifiedDateTimestamps;
 
+    /**
+     * @since 2.16
+     */
     protected InstantDeserializer(Class<T> supportedType,
             DateTimeFormatter formatter,
             Function<TemporalAccessor, T> parsedToValue,
@@ -174,6 +177,24 @@ public class InstantDeserializer<T extends Temporal>
         this._readTimestampsAsNanosOverride = null;
         _normalizeZoneId = normalizeZoneId;
         _alwaysAllowStringifiedDateTimestamps = readNumericStringsAsTimestamp;
+    }
+
+    /**
+     * @deprecated Since 2.16, use {@link #InstantDeserializer(Class,DateTimeFormatter,
+     * Function,Function,Function,BiFunction,boolean,boolean,boolean)} instead.
+     */
+    @Deprecated()
+    protected InstantDeserializer(Class<T> supportedType,
+                                  DateTimeFormatter formatter,
+                                  Function<TemporalAccessor, T> parsedToValue,
+                                  Function<FromIntegerArguments, T> fromMilliseconds,
+                                  Function<FromDecimalArguments, T> fromNanoseconds,
+                                  BiFunction<T, ZoneId, T> adjust,
+                                  boolean replaceZeroOffsetAsZ
+    ) {
+        this(supportedType, formatter, parsedToValue, fromMilliseconds, fromNanoseconds,
+                adjust, replaceZeroOffsetAsZ,
+                DEFAULT_NORMALIZE_ZONE_ID, DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS);
     }
 
     @SuppressWarnings("unchecked")

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -187,6 +187,6 @@ M.P. Korstanje (mpkorstanje@github)
   (2.16.0)
 
 Harald Kuhr (haraldk@github)
- * Reported #285: Breaking change in `InstantDeserializer API between 2.15 and 2.16
+ * Reported #286: Breaking change in `InstantDeserializer API between 2.15 and 2.16
   (2.16.1)
 

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -185,3 +185,8 @@ M.P. Korstanje (mpkorstanje@github)
  * Contributed #263: Add `JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_TIMESTAMPS` to allow parsing
    quoted numbers when using a custom DateTimeFormatter
   (2.16.0)
+
+Harald Kuhr (haraldk@github)
+ * Reported #285: Breaking change in `InstantDeserializer API between 2.15 and 2.16
+  (2.16.1)
+

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -10,6 +10,8 @@ Modules:
 
 2.16.1 (not yet released)
 
+#285: Breaking change in `InstantDeserializer API between 2.15 and 2.16
+ (reported by Harald K)
 #288: `LocalDateTime` serialization issue with custom-configured
   `LocalDateTimeSerializer`
  (reported by @mklinkj)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -10,7 +10,7 @@ Modules:
 
 2.16.1 (not yet released)
 
-#285: Breaking change in `InstantDeserializer API between 2.15 and 2.16
+#286: Breaking change in `InstantDeserializer API between 2.15 and 2.16
  (reported by Harald K)
 #288: `LocalDateTime` serialization issue with custom-configured
   `LocalDateTimeSerializer`


### PR DESCRIPTION
Recreated #287 to target 2.16 branch.
