### PR TITLE
add null check for typeIdDef in LocalDateTimeSerializer

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateSerializer.java
@@ -82,18 +82,22 @@ public class LocalDateSerializer extends JSR310FormattedSerializerBase<LocalDate
     {
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
                 typeSer.typeId(value, serializationShape(provider)));
-        // need to write out to avoid double-writing array markers
-        switch (typeIdDef.valueShape) {
-        case START_ARRAY:
-            _serializeAsArrayContents(value, g, provider);
-            break;
-        case VALUE_NUMBER_INT:
-            g.writeNumber(value.toEpochDay());
-            break;
-        default:
-            g.writeString((_formatter == null) ? value.toString() : value.format(_formatter));
+        if (typeIdDef == null) {
+            serialize(value, g, provider);
+        } else {
+            // need to write out to avoid double-writing array markers
+            switch (typeIdDef.valueShape) {
+                case START_ARRAY:
+                    _serializeAsArrayContents(value, g, provider);
+                    break;
+                case VALUE_NUMBER_INT:
+                    g.writeNumber(value.toEpochDay());
+                    break;
+                default:
+                    g.writeString((_formatter == null) ? value.toString() : value.format(_formatter));
+            }
+            typeSer.writeTypeSuffix(g, typeIdDef);
         }
-        typeSer.writeTypeSuffix(g, typeIdDef);
     }
 
     protected void _serializeAsArrayContents(LocalDate value, JsonGenerator g,

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
@@ -86,7 +86,7 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
                 typeSer.typeId(value, serializationShape(provider)));
         // need to write out to avoid double-writing array markers
-        if (typeIdDef.valueShape == JsonToken.START_ARRAY) {
+        if (typeIdDef != null && typeIdDef.valueShape == JsonToken.START_ARRAY) {
             _serializeAsArrayContents(value, g, provider);
         } else {
             DateTimeFormatter dtf = _formatter;

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/LocalDateTimeSerializer.java
@@ -85,17 +85,21 @@ public class LocalDateTimeSerializer extends JSR310FormattedSerializerBase<Local
     {
         WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
                 typeSer.typeId(value, serializationShape(provider)));
-        // need to write out to avoid double-writing array markers
-        if (typeIdDef != null && typeIdDef.valueShape == JsonToken.START_ARRAY) {
-            _serializeAsArrayContents(value, g, provider);
+        if (typeIdDef == null) {
+            serialize(value, g, provider);
         } else {
-            DateTimeFormatter dtf = _formatter;
-            if (dtf == null) {
-                dtf = _defaultFormatter();
+            // need to write out to avoid double-writing array markers
+            if (typeIdDef.valueShape == JsonToken.START_ARRAY) {
+                _serializeAsArrayContents(value, g, provider);
+            } else {
+                DateTimeFormatter dtf = _formatter;
+                if (dtf == null) {
+                    dtf = _defaultFormatter();
+                }
+                g.writeString(value.format(dtf));
             }
-            g.writeString(value.format(dtf));
+            typeSer.writeTypeSuffix(g, typeIdDef);
         }
-        typeSer.writeTypeSuffix(g, typeIdDef);
     }
 
     private final void _serializeAsArrayContents(LocalDateTime value, JsonGenerator g,


### PR DESCRIPTION
relates to https://github.com/FasterXML/jackson-databind/issues/4258