### PR TITLE
Support more formats in `ZonedDateTimeKeyDeserializer`

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.datatype.jsr310.deser.key;
 import java.io.IOException;
 import java.time.DateTimeException;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 
@@ -17,9 +16,8 @@ public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
 
     @Override
     protected ZonedDateTime deserialize(String key, DeserializationContext ctxt) throws IOException {
-        // not serializing timezone data yet
         try {
-            return ZonedDateTime.parse(key, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            return ZonedDateTime.parse(key);
         } catch (DateTimeException e) {
             return _handleDateTimeException(ctxt, ZonedDateTime.class, e, key);
         }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializer.java
@@ -17,6 +17,7 @@ public class ZonedDateTimeKeyDeserializer extends Jsr310KeyDeserializer {
     @Override
     protected ZonedDateTime deserialize(String key, DeserializationContext ctxt) throws IOException {
         try {
+            // Not supplying a formatter allows the use of all supported formats
             return ZonedDateTime.parse(key);
         } catch (DateTimeException e) {
             return _handleDateTimeException(ctxt, ZonedDateTime.class, e, key);

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
@@ -10,6 +10,7 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.*;
 
 public class ZonedDateTimeKeyDeserializerTest {
 
@@ -45,12 +46,29 @@ public class ZonedDateTimeKeyDeserializerTest {
 
     @Test
     public void ZonedDateTime_with_place_name_can_be_deserialized() throws Exception {
+        String javaVersion = System.getProperty("java.version");
+        assumeFalse(javaVersion.startsWith("1.8"));
+
         String input = "2015-07-24T12:23:34.184Z[Europe/London]";
 
         Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
 
         Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
         assertEquals("2015-07-24T13:23:34.184+01:00[Europe/London]", entry.getKey().toString());
+    }
+
+    @Test
+    public void ZonedDateTime_with_place_name_can_be_deserialized_Java_8() throws Exception {
+        // Java 8 parses this format differently for some reason
+        String javaVersion = System.getProperty("java.version");
+        assumeTrue(javaVersion.startsWith("1.8"));
+
+        String input = "2015-07-24T12:23:34.184Z[Europe/London]";
+
+        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
+
+        Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
+        assertEquals("2015-07-24T12:23:34.184+01:00[Europe/London]", entry.getKey().toString());
     }
 
     @Test

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
@@ -59,7 +59,7 @@ public class ZonedDateTimeKeyDeserializerTest {
 
     @Test
     public void ZonedDateTime_with_place_name_can_be_deserialized_Java_8() throws Exception {
-        // Java 8 parses this format differently for some reason
+        // Java 8 parses this format incorrectly due to https://bugs.openjdk.org/browse/JDK-8066982
         String javaVersion = System.getProperty("java.version");
         assumeTrue(javaVersion.startsWith("1.8"));
 

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
@@ -1,10 +1,11 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.junit.BeforeClass;
+
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -12,47 +13,36 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.*;
 
-public class ZonedDateTimeKeyDeserializerTest {
-
-    private static ObjectMapper objectMapper;
-    private final TypeReference<Map<ZonedDateTime, String>> MAP_TYPE_REF = new TypeReference<Map<ZonedDateTime, String>>() {
-		};
-
-    @BeforeClass
-    public static void beforeClass() {
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-    }
+// for [modules-java8#306]
+public class ZonedDateTimeKeyDeserializerTest
+    extends ModuleTestBase
+{
+    private final ObjectMapper MAPPER = newMapper();
+    private final TypeReference<Map<ZonedDateTime, String>> MAP_TYPE_REF
+        = new TypeReference<Map<ZonedDateTime, String>>() {};
 
     @Test
     public void Instant_style_can_be_deserialized() throws Exception {
-        String input = "2015-07-24T12:23:34.184Z";
-
-        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
-
+        Map<ZonedDateTime, String> map = MAPPER.readValue(getMap("2015-07-24T12:23:34.184Z"),
+                MAP_TYPE_REF);
         Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
         assertEquals("2015-07-24T12:23:34.184Z", entry.getKey().toString());
     }
 
     @Test
     public void ZonedDateTime_with_zone_name_can_be_deserialized() throws Exception {
-        String input = "2015-07-24T12:23:34.184Z[UTC]";
-
-        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
-
+        Map<ZonedDateTime, String> map = MAPPER.readValue(getMap("2015-07-24T12:23:34.184Z[UTC]"),
+                MAP_TYPE_REF);
         Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
         assertEquals("2015-07-24T12:23:34.184Z[UTC]", entry.getKey().toString());
     }
 
     @Test
     public void ZonedDateTime_with_place_name_can_be_deserialized() throws Exception {
-        String javaVersion = System.getProperty("java.version");
-        assumeFalse(javaVersion.startsWith("1.8"));
+        assumeFalse(System.getProperty("java.version").startsWith("1.8"));
 
-        String input = "2015-07-24T12:23:34.184Z[Europe/London]";
-
-        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
-
+        Map<ZonedDateTime, String> map = MAPPER.readValue(getMap("2015-07-24T12:23:34.184Z[Europe/London]"),
+                MAP_TYPE_REF);
         Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
         assertEquals("2015-07-24T13:23:34.184+01:00[Europe/London]", entry.getKey().toString());
     }
@@ -60,23 +50,18 @@ public class ZonedDateTimeKeyDeserializerTest {
     @Test
     public void ZonedDateTime_with_place_name_can_be_deserialized_Java_8() throws Exception {
         // Java 8 parses this format incorrectly due to https://bugs.openjdk.org/browse/JDK-8066982
-        String javaVersion = System.getProperty("java.version");
-        assumeTrue(javaVersion.startsWith("1.8"));
+        assumeTrue(System.getProperty("java.version").startsWith("1.8"));
 
-        String input = "2015-07-24T12:23:34.184Z[Europe/London]";
-
-        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
-
+        Map<ZonedDateTime, String> map = MAPPER.readValue(getMap("2015-07-24T12:23:34.184Z[Europe/London]"),
+                MAP_TYPE_REF);
         Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
         assertEquals("2015-07-24T12:23:34.184+01:00[Europe/London]", entry.getKey().toString());
     }
 
     @Test
     public void ZonedDateTime_with_offset_can_be_deserialized() throws Exception {
-        String input = "2015-07-24T12:23:34.184+02:00";
-
-        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
-
+        Map<ZonedDateTime, String> map = MAPPER.readValue(getMap("2015-07-24T12:23:34.184+02:00"),
+                MAP_TYPE_REF);
         Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
         assertEquals("2015-07-24T12:23:34.184+02:00", entry.getKey().toString());
     }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
@@ -1,6 +1,5 @@
 package com.fasterxml.jackson.datatype.jsr310.deser.key;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -25,7 +24,7 @@ public class ZonedDateTimeKeyDeserializerTest {
     }
 
     @Test
-    public void Instant_style_can_be_deserialized() throws JsonProcessingException {
+    public void Instant_style_can_be_deserialized() throws Exception {
         String input = "2015-07-24T12:23:34.184Z";
 
         Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
@@ -35,7 +34,7 @@ public class ZonedDateTimeKeyDeserializerTest {
     }
 
     @Test
-    public void ZonedDateTime_with_zone_name_can_be_deserialized() throws JsonProcessingException {
+    public void ZonedDateTime_with_zone_name_can_be_deserialized() throws Exception {
         String input = "2015-07-24T12:23:34.184Z[UTC]";
 
         Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
@@ -45,7 +44,7 @@ public class ZonedDateTimeKeyDeserializerTest {
     }
 
     @Test
-    public void ZonedDateTime_with_place_name_can_be_deserialized() throws JsonProcessingException {
+    public void ZonedDateTime_with_place_name_can_be_deserialized() throws Exception {
         String input = "2015-07-24T12:23:34.184Z[Europe/London]";
 
         Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
@@ -55,7 +54,7 @@ public class ZonedDateTimeKeyDeserializerTest {
     }
 
     @Test
-    public void ZonedDateTime_with_offset_can_be_deserialized() throws JsonProcessingException {
+    public void ZonedDateTime_with_offset_can_be_deserialized() throws Exception {
         String input = "2015-07-24T12:23:34.184+02:00";
 
         Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/key/ZonedDateTimeKeyDeserializerTest.java
@@ -1,0 +1,70 @@
+package com.fasterxml.jackson.datatype.jsr310.deser.key;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ZonedDateTimeKeyDeserializerTest {
+
+    private static ObjectMapper objectMapper;
+    private final TypeReference<Map<ZonedDateTime, String>> MAP_TYPE_REF = new TypeReference<Map<ZonedDateTime, String>>() {
+		};
+
+    @BeforeClass
+    public static void beforeClass() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Test
+    public void Instant_style_can_be_deserialized() throws JsonProcessingException {
+        String input = "2015-07-24T12:23:34.184Z";
+
+        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
+
+        Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
+        assertEquals("2015-07-24T12:23:34.184Z", entry.getKey().toString());
+    }
+
+    @Test
+    public void ZonedDateTime_with_zone_name_can_be_deserialized() throws JsonProcessingException {
+        String input = "2015-07-24T12:23:34.184Z[UTC]";
+
+        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
+
+        Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
+        assertEquals("2015-07-24T12:23:34.184Z[UTC]", entry.getKey().toString());
+    }
+
+    @Test
+    public void ZonedDateTime_with_place_name_can_be_deserialized() throws JsonProcessingException {
+        String input = "2015-07-24T12:23:34.184Z[Europe/London]";
+
+        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
+
+        Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
+        assertEquals("2015-07-24T13:23:34.184+01:00[Europe/London]", entry.getKey().toString());
+    }
+
+    @Test
+    public void ZonedDateTime_with_offset_can_be_deserialized() throws JsonProcessingException {
+        String input = "2015-07-24T12:23:34.184+02:00";
+
+        Map<ZonedDateTime, String> map = objectMapper.readValue(getMap(input), MAP_TYPE_REF);
+
+        Map.Entry<ZonedDateTime, String> entry = map.entrySet().iterator().next();
+        assertEquals("2015-07-24T12:23:34.184+02:00", entry.getKey().toString());
+    }
+
+    private static String getMap(String input) {
+        return "{\"" + input + "\": \"This is a string\"}";
+    }
+}

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,15 @@ Modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.0 (not yet released)
+
+No changes since 2.17
+
+2.17.1 (not yet released)
+
+#306: Only `DateTimeFormatter.ISO_OFFSET_DATE_TIME` accepted by `ZonedDateTimeKeyDeserializer`
+ (fix contributed by @caluml)
+
 2.17.0 (12-Mar-2024)
 
 #274: Deserializing `java.time.Month` from an int causes an off-by-one


### PR DESCRIPTION
ZonedDateTimeKeyDeserializer was only able to deserialize ZonedDateTimes that matched the  DateTimeFormatter.ISO_OFFSET_DATE_TIME format.

This PR removes that restriction, allowing for more formats, such as
 * 2015-07-24T12:23:34.184Z[UTC]
 * 2015-07-24T13:23:34.184+01:00[Europe/London]
 * 2015-07-24T12:23:34.184+02:00

to be used as keys.