### PR TITLE
Fix #308, Can't deserialize `OffsetDateTime.MIN` and `OffsetDateTime.MAX`

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -67,17 +67,12 @@ public class InstantDeserializer<T extends Temporal>
      */
     protected static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("[+-][0-9]{4}(?=\\[|$)");
 
-    /**
-     *
-     * @param args
-     * @return
-     */
     private static OffsetDateTime decimalToOffsetDateTime(FromDecimalArguments args) {
-        // [jackson-modules-java8#308] Fix can't deserialize OffsetDateTime.MIN: Invalid value for EpochDay
+        // [jackson-modules-java8#308] Since 2.18.2 : Fix can't deserialize OffsetDateTime.MIN: Invalid value for EpochDay
         if (args.integer == OffsetDateTime.MIN.toEpochSecond() && args.fraction == OffsetDateTime.MIN.getNano()) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(OffsetDateTime.MIN.toEpochSecond(), OffsetDateTime.MIN.getNano()), OffsetDateTime.MIN.getOffset());
         }
-        // [jackson-modules-java8#308] For OffsetDateTime.MAX case
+        // [jackson-modules-java8#308] Since 2.18.2 : For OffsetDateTime.MAX case
         if (args.integer == OffsetDateTime.MAX.toEpochSecond() && args.fraction == OffsetDateTime.MAX.getNano()) {
             return OffsetDateTime.ofInstant(Instant.ofEpochSecond(OffsetDateTime.MAX.toEpochSecond(), OffsetDateTime.MAX.getNano()), OffsetDateTime.MAX.getOffset());
         }
@@ -559,17 +554,6 @@ public class InstantDeserializer<T extends Temporal>
             this.integer = integer;
             this.fraction = fraction;
             this.zoneId = zoneId;
-        }
-
-        public static boolean matches(FromDecimalArguments a, FromDecimalArguments b) {
-            if (a == b) {
-                return true;
-            }
-            if (a == null || b == null) {
-                return false;
-            }
-            return a.integer == b.integer && a.fraction == b.fraction
-                    && a.zoneId.equals(b.zoneId);
         }
     }
 }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -79,7 +79,6 @@ public class InstantDeserializer<T extends Temporal>
         return OffsetDateTime.ofInstant(Instant.ofEpochSecond(args.integer, args.fraction), args.zoneId);
     }
 
-
     public static final InstantDeserializer<Instant> INSTANT = new InstantDeserializer<>(
             Instant.class, DateTimeFormatter.ISO_INSTANT,
             Instant::from,

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/InstantDeserializer.java
@@ -61,12 +61,13 @@ public class InstantDeserializer<T extends Temporal>
         = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();
 
     /**
-     * Constants used to check if ISO 8601 time string is colonless. See [jackson-modules-java8#131]
+     * Constants used to check if ISO 8601 time string is colon-less. See [jackson-modules-java8#131]
      *
      * @since 2.13
      */
     protected static final Pattern ISO8601_COLONLESS_OFFSET_REGEX = Pattern.compile("[+-][0-9]{4}(?=\\[|$)");
 
+    // @since 2.18.2
     private static OffsetDateTime decimalToOffsetDateTime(FromDecimalArguments args) {
         // [jackson-modules-java8#308] Since 2.18.2 : Fix can't deserialize OffsetDateTime.MIN: Invalid value for EpochDay
         if (args.integer == OffsetDateTime.MIN.toEpochSecond() && args.fraction == OffsetDateTime.MIN.getNano()) {

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -10,6 +10,7 @@ import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Feature;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -801,6 +802,24 @@ public class OffsetDateTimeDeserTest
         OffsetDateTime actualValue = (OffsetDateTime) value;
         assertIsEqual(date, actualValue);
         assertEquals(date.getOffset(),actualValue.getOffset());
+    }
+
+    // [jackson-modules-java8#308] Can't deserialize OffsetDateTime.MIN: Invalid value for EpochDay
+    @Test
+    public void testOffsetDateTimeMinOrMax()
+            throws Exception
+    {
+        _testOffsetDateTimeMinOrMax(OffsetDateTime.MIN);
+        _testOffsetDateTimeMinOrMax(OffsetDateTime.MAX);
+    }
+
+    private void _testOffsetDateTimeMinOrMax(OffsetDateTime offsetDateTime)
+        throws Exception
+    {
+        ObjectMapper mapper = newMapper();
+        String ser = mapper.writeValueAsString(offsetDateTime);
+        OffsetDateTime result = mapper.readValue(ser, OffsetDateTime.class);
+        assertIsEqual(offsetDateTime, result);
     }
 
     private static void assertIsEqual(OffsetDateTime expected, OffsetDateTime actual)

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -805,8 +805,7 @@ public class OffsetDateTimeDeserTest
 
     // [jackson-modules-java8#308] Can't deserialize OffsetDateTime.MIN: Invalid value for EpochDay
     @Test
-    public void testOffsetDateTimeMinOrMax()
-            throws Exception
+    public void testOffsetDateTimeMinOrMax() throws Exception
     {
         _testOffsetDateTimeMinOrMax(OffsetDateTime.MIN);
         _testOffsetDateTimeMinOrMax(OffsetDateTime.MAX);
@@ -815,9 +814,8 @@ public class OffsetDateTimeDeserTest
     private void _testOffsetDateTimeMinOrMax(OffsetDateTime offsetDateTime)
         throws Exception
     {
-        ObjectMapper mapper = newMapper();
-        String ser = mapper.writeValueAsString(offsetDateTime);
-        OffsetDateTime result = mapper.readValue(ser, OffsetDateTime.class);
+        String ser = MAPPER.writeValueAsString(offsetDateTime);
+        OffsetDateTime result = MAPPER.readValue(ser, OffsetDateTime.class);
         assertIsEqual(offsetDateTime, result);
     }
 

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -10,7 +10,6 @@ import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Feature;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -203,3 +203,7 @@ Emanuel Trandafir (@etrandafir93)
 Ólafur Bragason (@olibraga)
  * Reported #319: `java.time.DateTimeException` serialization fails
   (2.18.1)
+
+Joo Hyuk Kim (@JooHyukKim)
+ * Fixed #308: Can't deserialize `OffsetDateTime.MIN`: Invalid value for EpochDay
+  (2.18.2)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,12 @@ Modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.2 (not yet released)
+
+#308: Can't deserialize `OffsetDateTime.MIN`: Invalid value for EpochDay
+ (reported by @sszuev)
+ (fix by Joo-Hyuk K)
+
 2.18.1 (28-Oct-2024)
 
 #319: `java.time.DateTimeException` serialization fails


### PR DESCRIPTION
Let's handle cases specifically for MIN & MAX (#308)