### PR TITLE
(v2.17.4) Add test against #124 

### DIFF
--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
@@ -655,6 +655,29 @@ public class LocalDateTimeDeserTest
         assertEquals(w.value, LocalDateTime.of(2019, 11, 30, 20, 45));
     }
 
+    // [datatype-jsr310#124] Issue serializing and deserializing LocalDateTime.MAX and LocalDateTime.MIN
+    @Test
+    public void testDeserializationOfLocalDateTimeMax() throws Exception
+    {
+        ObjectMapper enabledMapper = mapperBuilder()
+                .enable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).build();
+        _testLocalDateTimeRoundTrip(enabledMapper, LocalDateTime.MAX);
+        _testLocalDateTimeRoundTrip(enabledMapper, LocalDateTime.MIN);
+
+        ObjectMapper disabledMapper = mapperBuilder()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).build();
+        _testLocalDateTimeRoundTrip(disabledMapper, LocalDateTime.MAX);
+        _testLocalDateTimeRoundTrip(disabledMapper, LocalDateTime.MIN);
+    }
+
+    private void _testLocalDateTimeRoundTrip(ObjectMapper mapper, LocalDateTime localDateTime)
+        throws Exception
+    {
+        String ser = mapper.writeValueAsString(localDateTime);
+        LocalDateTime result = mapper.readValue(ser, LocalDateTime.class);
+        assertEquals(localDateTime, result);
+    }
+
     private void expectSuccess(ObjectReader reader, Object exp, String json) throws IOException {
         final LocalDateTime value = reader.readValue(a2q(json));
         assertNotNull("The value should not be null.", value);

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -10,7 +10,11 @@ Modules:
 
 2.18.0 (not yet released)
 
-No changes since 2.17
+2.17.4 (not yet released)
+
+#124 Issue serializing and deserializing `LocalDateTime.MAX` and `LocalDateTime.MIN`
+ (reported by @bachilast)
+ (fix verified by Joo-Hyuk K)
 
 2.17.3 (01-Nov-2024)
 2.17.2 (05-Jul-2024)


### PR DESCRIPTION
verifies #124 works in 2.17.4 version as well.