### PR TITLE
fix #333 `@JsonFormat` with pattern should override `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/InstantSerializerBase.java
@@ -57,12 +57,12 @@ public abstract class InstantSerializerBase<T extends Temporal>
 
     protected InstantSerializerBase(Class<T> supportedType, ToLongFunction<T> getEpochMillis,
             ToLongFunction<T> getEpochSeconds, ToIntFunction<T> getNanoseconds,
-            DateTimeFormatter formatter)
+            DateTimeFormatter defaultFormat)
     {
         // Bit complicated, just because we actually want to "hide" default formatter,
         // so that it won't accidentally force use of textual presentation
         super(supportedType, null);
-        defaultFormat = formatter;
+        this.defaultFormat = defaultFormat;
         this.getEpochMillis = getEpochMillis;
         this.getEpochSeconds = getEpochSeconds;
         this.getNanoseconds = getNanoseconds;
@@ -147,7 +147,7 @@ public abstract class InstantSerializerBase<T extends Temporal>
     // @since 2.12
     protected String formatValue(T value, SerializerProvider provider)
     {
-        DateTimeFormatter formatter = (_formatter != null) ? _formatter : defaultFormat;
+        DateTimeFormatter formatter = (_formatter == null) ? defaultFormat :_formatter;
         if (formatter != null) {
             if (formatter.getZone() == null) { // timezone set if annotated on property
                 // If the user specified to use the context TimeZone explicitly, and the formatter provided doesn't contain a TZ

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/JSR310FormattedSerializerBase.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/JSR310FormattedSerializerBase.java
@@ -59,7 +59,7 @@ abstract class JSR310FormattedSerializerBase<T>
     protected final Boolean _useNanoseconds;
 
     /**
-     * Specific format to use, if not default format: non null value
+     * Specific format to use, if not default format: non-null value
      * also indicates that serialization is to be done as JSON String,
      * not numeric timestamp, unless {@code #_useTimestamp} is true.
      */

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
@@ -82,6 +82,11 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     public void serialize(ZonedDateTime value, JsonGenerator g, SerializerProvider provider)
         throws IOException
     {
+        // [modules-java8#333]: `@JsonFormat` with pattern should override `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
+        if (_formatter != null && _shape == JsonFormat.Shape.STRING) {
+            super.serialize(value, g, provider);
+            return;
+        }
         if (!useTimestamp(provider)) {
             if (shouldWriteWithZoneId(provider)) {
                 // write with zone

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
@@ -97,6 +97,17 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
         super.serialize(value, g, provider);
     }
 
+    @Override
+    protected String formatValue(ZonedDateTime value, SerializerProvider provider) {
+        String formatted = super.formatValue(value, provider);
+        if (_formatter != null && _shape == JsonFormat.Shape.STRING) {
+            if (shouldWriteWithZoneId(provider)) {
+                formatted += "[" + value.getZone().getId() + "]";
+            }
+        }
+        return formatted;
+    }
+
     /**
      * @since 2.8
      */

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
@@ -100,8 +100,9 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     @Override
     protected String formatValue(ZonedDateTime value, SerializerProvider provider) {
         String formatted = super.formatValue(value, provider);
+        // [modules-java8#333]: `@JsonFormat` with pattern should override `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
         if (_formatter != null && _shape == JsonFormat.Shape.STRING) {
-            if (shouldWriteWithZoneId(provider)) {
+            if (Boolean.TRUE.equals(_writeZoneId)) {
                 formatted += "[" + value.getZone().getId() + "]";
             }
         }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializer.java
@@ -82,13 +82,12 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     public void serialize(ZonedDateTime value, JsonGenerator g, SerializerProvider provider)
         throws IOException
     {
-        // [modules-java8#333]: `@JsonFormat` with pattern should override `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
-        if (_formatter != null && _shape == JsonFormat.Shape.STRING) {
-            super.serialize(value, g, provider);
-            return;
-        }
         if (!useTimestamp(provider)) {
-            if (shouldWriteWithZoneId(provider)) {
+            // [modules-java8#333]: `@JsonFormat` with pattern should override
+            //   `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
+            if ((_formatter != null) && (_shape == JsonFormat.Shape.STRING)) {
+                ; // use default handling
+            } else if (shouldWriteWithZoneId(provider)) {
                 // write with zone
                 g.writeString(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(value));
                 return;
@@ -100,8 +99,10 @@ public class ZonedDateTimeSerializer extends InstantSerializerBase<ZonedDateTime
     @Override
     protected String formatValue(ZonedDateTime value, SerializerProvider provider) {
         String formatted = super.formatValue(value, provider);
-        // [modules-java8#333]: `@JsonFormat` with pattern should override `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
+        // [modules-java8#333]: `@JsonFormat` with pattern should override
+        //   `SerializationFeature.WRITE_DATES_WITH_ZONE_ID`
         if (_formatter != null && _shape == JsonFormat.Shape.STRING) {
+            // Why not `if (shouldWriteWithZoneId(provider))` ?
             if (Boolean.TRUE.equals(_writeZoneId)) {
                 formatted += "[" + value.getZone().getId() + "]";
             }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/WriteZoneIdTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/WriteZoneIdTest.java
@@ -21,7 +21,7 @@ public class WriteZoneIdTest extends ModuleTestBase
 {
     static class DummyClassWithDate {
         @JsonFormat(shape = JsonFormat.Shape.STRING,
-                pattern = "dd-MM-yyyy hh:mm:ss Z",
+                pattern = "dd-MM-yyyy'T'hh:mm:ss Z",
                 with = JsonFormat.Feature.WRITE_DATES_WITH_ZONE_ID)
         public ZonedDateTime date;
 
@@ -73,7 +73,7 @@ public class WriteZoneIdTest extends ModuleTestBase
         // 30-Jun-2016, tatu: Exact time seems to vary a bit based on DST, so let's actually
         //    just verify appending of timezone id itself:
         String json = MAPPER.writeValueAsString(input);
-        if (!json.contains("\"1970-01-01T")) {
+        if (!json.contains("\"01-01-1970T")) {
             Assert.fail("Should contain time prefix, did not: "+json);
         }
         String match = String.format("[%s]", ZONE_ID_STR);

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerWithJsonFormat333Test.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerWithJsonFormat333Test.java
@@ -1,20 +1,21 @@
 package com.fasterxml.jackson.datatype.jsr310.ser;
 
+import java.time.ZonedDateTime;
+
+import org.junit.Test;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
-import org.junit.Test;
-
-import java.time.ZonedDateTime;
 
 import static org.junit.Assert.assertEquals;
 
-// [module-java8#333] : ZonedDateTime serialization with @JsonFormat pattern never uses it while WRITE_DATES_WITH_ZONE_ID enabled #333
-public class ZonedDateTimeSerializationWithJsonFormat333Test
+// [module-java8#333]: ZonedDateTime serialization with @JsonFormat pattern never uses
+//  while WRITE_DATES_WITH_ZONE_ID enabled #333
+public class ZonedDateTimeSerWithJsonFormat333Test
     extends ModuleTestBase
 {
-
     public static class ContainerWithPattern333 {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss z")
         public ZonedDateTime value;
@@ -35,9 +36,7 @@ public class ZonedDateTimeSerializationWithJsonFormat333Test
         ContainerWithPattern333 input = new ContainerWithPattern333();
         input.value = zonedDateTime;
 
-        String json = MAPPER.writeValueAsString(input);
-
-        assertEquals(a2q("{'value':'2024-11-15 18:27:06 CET'}"), json);
+        assertEquals(a2q("{'value':'2024-11-15 18:27:06 CET'}"),
+                MAPPER.writeValueAsString(input));
     }
-
 }

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializationWithJsonFormat333Test.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/ser/ZonedDateTimeSerializationWithJsonFormat333Test.java
@@ -1,0 +1,43 @@
+package com.fasterxml.jackson.datatype.jsr310.ser;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+// [module-java8#333] : ZonedDateTime serialization with @JsonFormat pattern never uses it while WRITE_DATES_WITH_ZONE_ID enabled #333
+public class ZonedDateTimeSerializationWithJsonFormat333Test
+    extends ModuleTestBase
+{
+
+    public static class ContainerWithPattern333 {
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss z")
+        public ZonedDateTime value;
+    }
+
+    public static class ContainerWithoutPattern333 {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public ZonedDateTime value;
+    }
+
+    private final ObjectMapper MAPPER = mapperBuilder().enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID).build();
+
+    @Test
+    public void testJsonFormatOverridesSerialization() throws Exception
+    {
+        // ISO-8601 string for ZonedDateTime
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2024-11-15T18:27:06.921054+01:00[Europe/Berlin]");
+        ContainerWithPattern333 input = new ContainerWithPattern333();
+        input.value = zonedDateTime;
+
+        String json = MAPPER.writeValueAsString(input);
+
+        assertEquals(a2q("{'value':'2024-11-15 18:27:06 CET'}"), json);
+    }
+
+}

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -8,6 +8,13 @@ Modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.3 (not yet released)
+
+#333: `ZonedDateTime` serialization with `@JsonFormat.pattern` never uses it
+  while `WRITE_DATES_WITH_ZONE_ID` enabled
+ (reported by @verve111)
+ (fix by Joo-Hyuk K)
+
 2.18.2 (27-Nov-2024)
 
 #308: Can't deserialize `OffsetDateTime.MIN`: Invalid value for EpochDay


### PR DESCRIPTION
fixes #333 