### PR TITLE
Optimize InstantDeserializer addInColonToOffsetIfMissing

### DIFF
--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OffsetDateTimeDeserTest.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -809,6 +810,40 @@ public class OffsetDateTimeDeserTest
     {
         _testOffsetDateTimeMinOrMax(OffsetDateTime.MIN);
         _testOffsetDateTimeMinOrMax(OffsetDateTime.MAX);
+    }
+
+    @Test
+    public void OffsetDateTime_with_offset_can_be_deserialized() throws Exception {
+        ObjectReader r = MAPPER.readerFor(OffsetDateTime.class)
+                .without(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+
+        String base = "2015-07-24T12:23:34.184";
+        for (String offset : Arrays.asList("+00", "-00")) {
+            String time = base + offset;
+            if (!System.getProperty("java.version").startsWith("1.8")) {
+                // JDK 8 cannot parse hour offsets without minutes
+                assertIsEqual(OffsetDateTime.parse("2015-07-24T12:23:34.184Z"), r.readValue('"' + time + '"'));
+            }
+            assertIsEqual(OffsetDateTime.parse("2015-07-24T12:23:34.184Z"), r.readValue('"' + time + "00" + '"'));
+            assertIsEqual(OffsetDateTime.parse("2015-07-24T12:23:34.184Z"), r.readValue('"' + time + ":00" + '"'));
+            assertIsEqual(OffsetDateTime.parse("2015-07-24T12:23:34.184" + offset + ":30"), r.readValue('"' + time + "30" + '"'));
+            assertIsEqual(OffsetDateTime.parse("2015-07-24T12:23:34.184" + offset + ":30"), r.readValue('"' + time + ":30" + '"'));
+        }
+
+        for (String prefix : Arrays.asList("-", "+")) {
+            for (String hours : Arrays.asList("00", "01", "02", "03", "11", "12")) {
+                String time = base + prefix + hours;
+                OffsetDateTime expectedHour = OffsetDateTime.parse(time + ":00");
+                if (!System.getProperty("java.version").startsWith("1.8")) {
+                    // JDK 8 cannot parse hour offsets without minutes
+                    assertIsEqual(expectedHour, r.readValue('"' + time + '"'));
+                }
+                assertIsEqual(expectedHour, r.readValue('"' + time + "00" + '"'));
+                assertIsEqual(expectedHour, r.readValue('"' + time + ":00" + '"'));
+                assertIsEqual(OffsetDateTime.parse(time + ":30"), r.readValue('"' + time + "30" + '"'));
+                assertIsEqual(OffsetDateTime.parse(time + ":30"), r.readValue('"' + time + ":30" + '"'));
+            }
+        }
     }
 
     private void _testOffsetDateTimeMinOrMax(OffsetDateTime offsetDateTime)

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/ZonedDateTimeDeserTest.java
@@ -18,11 +18,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -282,6 +284,39 @@ public class ZonedDateTimeDeserTest extends ModuleTestBase
                 wrapper.value);
     }
 
+    @Test
+    public void ZonedDateTime_with_offset_can_be_deserialized() throws Exception {
+        ObjectReader r = newMapper().readerFor(ZonedDateTime.class)
+                .without(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+
+        String base = "2015-07-24T12:23:34.184";
+        for (String offset : Arrays.asList("+00", "-00")) {
+            String time = base + offset;
+            if (!System.getProperty("java.version").startsWith("1.8")) {
+                // JDK 8 cannot parse hour offsets without minutes
+                assertEquals(ZonedDateTime.parse("2015-07-24T12:23:34.184Z"), r.readValue('"' + time + '"'));
+            }
+            assertEquals(ZonedDateTime.parse("2015-07-24T12:23:34.184Z"), r.readValue('"' + time + "00" + '"'));
+            assertEquals(ZonedDateTime.parse("2015-07-24T12:23:34.184Z"), r.readValue('"' + time + ":00" + '"'));
+            assertEquals(ZonedDateTime.parse("2015-07-24T12:23:34.184" + offset + ":30" ), r.readValue('"' + time + "30" + '"'));
+            assertEquals(ZonedDateTime.parse("2015-07-24T12:23:34.184" + offset + ":30" ), r.readValue('"' + time + ":30" + '"'));
+        }
+
+        for (String prefix : Arrays.asList("-", "+")) {
+            for (String hours : Arrays.asList("00", "01", "02", "03", "11", "12")) {
+                String time = base + prefix + hours;
+                ZonedDateTime expectedHour = ZonedDateTime.parse(time + ":00");
+                if (!System.getProperty("java.version").startsWith("1.8")) {
+                    // JDK 8 cannot parse hour offsets without minutes
+                    assertEquals(expectedHour, r.readValue('"' + time + '"'));
+                }
+                assertEquals(expectedHour, r.readValue('"' + time + "00" + '"'));
+                assertEquals(expectedHour, r.readValue('"' + time + ":00" + '"'));
+                assertEquals(ZonedDateTime.parse(time + ":30"), r.readValue('"' + time + "30" + '"'));
+                assertEquals(ZonedDateTime.parse(time + ":30"), r.readValue('"' + time + ":30" + '"'));
+            }
+        }
+    }
 
     private void expectFailure(String json) throws Throwable {
         try {


### PR DESCRIPTION
When using Jackson to deserialize timestamps with formatter of `DateTimeFormatter.ISO_OFFSET_DATE_TIME` or `DateTimeFormatter.ISO_ZONED_DATE_TIME`, a lot of time is spent in `InstantDeserializer::addInColonToOffsetIfMissing` allocating and performing regex matching on possible timezone offset, even if the input timestamp is already in a valid ISO 8601 format with explicit zone of `Z` or with colon separated offset.

Similar to https://github.com/FasterXML/jackson-modules-java8/pull/266


```
# 2021 MacBookPro M1 Pro
# JMH version: 1.37
# VM version: JDK 21.0.5, OpenJDK 64-Bit Server VM, 21.0.5+11-LTS
```

## Before (2.18.2)

```
Benchmark                                    Mode  Cnt     Score    Error  Units
InstantDeserializerBenchmark.offsetDateTime  avgt    5   942.358 ± 21.485  ns/op
InstantDeserializerBenchmark.zonedDateTime   avgt    5  1025.040 ± 37.269  ns/op
```


## After (2.19.0-SNAPSHOT)

```
Benchmark                                    Mode  Cnt    Score     Error  Units
InstantDeserializerBenchmark.offsetDateTime  avgt    5  705.542 ±  20.482  ns/op
InstantDeserializerBenchmark.zonedDateTime   avgt    5  850.149 ± 219.331  ns/op
```


```java
import com.fasterxml.jackson.databind.ObjectMapper;
import com.fasterxml.jackson.databind.json.JsonMapper;
import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
import java.time.OffsetDateTime;
import java.time.ZoneOffset;
import java.time.ZonedDateTime;
import java.time.format.DateTimeFormatter;
import java.util.List;
import java.util.Locale;
import java.util.concurrent.TimeUnit;
import java.util.function.Function;
import java.util.stream.IntStream;
import java.util.stream.Stream;
import org.junit.jupiter.api.Test;
import org.junit.jupiter.params.ParameterizedTest;
import org.junit.jupiter.params.provider.MethodSource;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OperationsPerInvocation;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;
import org.openjdk.jmh.infra.Blackhole;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.options.OptionsBuilder;

@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
@Fork(1)
@State(Scope.Benchmark)
@SuppressWarnings({"designforextension", "NullAway", "CheckStyle"})
public class DateTimeDeserializerBenchmark {

    private static final ObjectMapper mapper = JsonMapper.builder()
            .defaultLocale(Locale.ENGLISH)
            .addModule(new JavaTimeModule())
            .build();

    private static final List<String> timestamps = timestamps();
    private static final int EXPECTED_TIMESTAMPS = 515;

    @Benchmark
    @OperationsPerInvocation(EXPECTED_TIMESTAMPS)
    public void zonedDateTime(Blackhole blackhole) throws Exception {
        for (String string : timestamps) {
            blackhole.consume(mapper.readValue(string, ZonedDateTime.class));
        }
    }

    @Benchmark
    @OperationsPerInvocation(EXPECTED_TIMESTAMPS)
    public void offsetDateTime(Blackhole blackhole) throws Exception {
        for (String string : timestamps) {
            blackhole.consume(mapper.readValue(string, OffsetDateTime.class));
        }
    }

    public static List<String> timestamps() {
        return Stream.of(
                        DateTimeFormatter.ISO_DATE_TIME,
                        DateTimeFormatter.ISO_INSTANT,
                        DateTimeFormatter.ISO_OFFSET_DATE_TIME,
                        DateTimeFormatter.ISO_ZONED_DATE_TIME)
                .flatMap(f -> IntStream.rangeClosed(-18, 18)
                        .mapToObj(h -> Stream.of(
                                f.format(OffsetDateTime.now(ZoneOffset.ofHours(h))),
                                f.format(OffsetDateTime.now(
                                        ZoneOffset.ofHoursMinutes(h, Math.abs(h) == 18 ? 0 : h < 0 ? -30 : 30)))))
                        .flatMap(Function.identity()))
                .flatMap(ts -> {
                    int lastColon = ts.lastIndexOf(':');
                    if (lastColon == -1 || lastColon != ts.length() - 3) {
                        return Stream.of(ts);
                    }
                    return Stream.of(
                            ts, new StringBuilder(ts).deleteCharAt(lastColon).toString());
                })
                .map(ts -> '"' + ts + '"')
                .toList();
    }

    public static void main(String[] _args) throws Exception {
        new Runner(new OptionsBuilder()
                        .include(DateTimeDeserializerBenchmark.class.getSimpleName())
                        .build())
                .run();
    }
}
```
