### PR TITLE
Time zone aware lenient parsing

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserializer.java
@@ -18,6 +18,7 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -161,8 +162,7 @@ public class LocalDateDeserializer extends JSR310DateTimeDeserializerBase<LocalD
                 if (string.length() > 10 && string.charAt(10) == 'T') {
                     if (isLenient()) {
                         if (string.endsWith("Z")) {
-                            return LocalDate.parse(string.substring(0, string.length() - 1),
-                                    DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                            return Instant.parse(string).atZone(ctxt.getTimeZone().toZoneId()).toLocalDate();
                         }
                         return LocalDate.parse(string, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
                     }

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserializer.java
@@ -18,6 +18,7 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
@@ -195,13 +196,10 @@ public class LocalDateTimeDeserializer
             if (_formatter == DEFAULT_FORMATTER) {
                 // ... only allow iff lenient mode enabled since
                 // JavaScript by default includes time and zone in JSON serialized Dates (UTC/ISO instant format).
-                // And if so, do NOT use zoned date parsing as that can easily produce
-                // incorrect answer.
                 if (string.length() > 10 && string.charAt(10) == 'T') {
                    if (string.endsWith("Z")) {
                        if (isLenient()) {
-                           return LocalDateTime.parse(string.substring(0, string.length()-1),
-                                   _formatter);
+                           return Instant.parse(string).atZone(ctxt.getTimeZone().toZoneId()).toLocalDateTime();
                        }
                        JavaType t = getValueType(ctxt);
                        return (LocalDateTime) ctxt.handleWeirdStringValue(t.getRawClass(),

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateDeserTest.java
@@ -9,6 +9,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 import java.util.Map;
+import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
@@ -151,6 +152,15 @@ public class LocalDateDeserTest extends ModuleTestBase
         assertEquals("The value is not correct.",
                 LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toLocalDate(),
                 value);
+    }
+
+    @Test
+    public void testDeserializationAsString04() throws Exception
+    {
+        ObjectReader reader = READER.with(TimeZone.getTimeZone(Z_BUDAPEST));
+        Instant instant = Instant.parse("2024-07-21T22:00:00Z");
+        LocalDate value = reader.readValue('"' + instant.toString() + '"');
+        assertEquals("The value is not correct.", LocalDate.parse("2024-07-22"), value);
     }
 
     @Test

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/LocalDateTimeDeserTest.java
@@ -261,14 +261,14 @@ public class LocalDateTimeDeserTest
         // First, defaults:
         assertEquals("The value is not correct.", EXP, r.readValue(input));
 
-        // but ensure that global timezone setting doesn't matter
+        // and ensure that global timezone setting matter
         LocalDateTime value = r.with(TimeZone.getTimeZone(Z_CHICAGO))
                 .readValue(input);
-        assertEquals("The value is not correct.", EXP, value);
+        assertEquals("The value is not correct.", EXP.minusHours(5), value);
 
         value = r.with(TimeZone.getTimeZone(Z_BUDAPEST))
                 .readValue(input);
-        assertEquals("The value is not correct.", EXP, value);
+        assertEquals("The value is not correct.", EXP.plusHours(2), value);
     }
 
     // [modules-java#94]: "Z" offset not allowed if strict mode


### PR DESCRIPTION
Resolves #342.

The current implementation of lenient parsing of `LocalDate` and `LocalDateTime` was implemented with the goal to always produce the values such that they need to be interpreted to be UTC.

In particular for `LocalDate` this can very easily lead to confusing behavior for users.

The proposed change only leads to a change in behavior when the `TimeZone` is explicitly set on the `ObjectMapper` and is different from `UTC`.