### PR TITLE
[JSTEP-10] Migrate modules `datatype` and `parameter-names` to `JUnit 5`

### DIFF
--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/ContextualOptional17Test.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/ContextualOptional17Test.java
@@ -5,9 +5,13 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.TimeZone;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ContextualOptional17Test extends ModuleTestBase
 {
@@ -30,6 +34,7 @@ public class ContextualOptional17Test extends ModuleTestBase
     /**********************************************************
      */
 
+    @Test
     public void testContextualOptionals() throws Exception
     {
         final ObjectMapper mapper = mapperWithModule();

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/CreatorTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/CreatorTest.java
@@ -2,10 +2,14 @@ package com.fasterxml.jackson.datatype.jdk8;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CreatorTest extends ModuleTestBase
 {
@@ -35,6 +39,7 @@ public class CreatorTest extends ModuleTestBase
      * Test to ensure that creator parameters use defaulting
      * (introduced in Jackson 2.6)
      */
+    @Test
     public void testCreatorWithOptionalDefault() throws Exception
     {
         CreatorWithOptionalStrings bean = MAPPER.readValue(
@@ -47,6 +52,7 @@ public class CreatorTest extends ModuleTestBase
         assertEquals("foo", bean.a.get());
     }
 
+    @Test
     public void testCreatorWithOptionalAbsentAsNull() throws Exception
     {
         Jdk8Module module = new Jdk8Module()

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/DoubleStreamSerializerTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/DoubleStreamSerializerTest.java
@@ -1,14 +1,14 @@
 package com.fasterxml.jackson.datatype.jdk8;
 
-import static org.junit.Assert.*;
-
 import java.io.IOException;
 import java.util.stream.DoubleStream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({ "unqualified-field-access", "javadoc" })
 public class DoubleStreamSerializerTest extends StreamTestBase {
@@ -21,7 +21,7 @@ public class DoubleStreamSerializerTest extends StreamTestBase {
 
     final String exceptionMessage = "DoubleStream peek threw";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/IntStreamSerializerTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/IntStreamSerializerTest.java
@@ -1,11 +1,11 @@
 package com.fasterxml.jackson.datatype.jdk8;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({ "unqualified-field-access", "javadoc" })
 public class IntStreamSerializerTest extends StreamTestBase {

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/JDKSerializabilityTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/JDKSerializabilityTest.java
@@ -3,9 +3,11 @@ package com.fasterxml.jackson.datatype.jdk8;
 import java.io.*;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JDKSerializabilityTest extends ModuleTestBase
 {

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/Java8OptionalUnwrappedTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/Java8OptionalUnwrappedTest.java
@@ -3,6 +3,8 @@ package com.fasterxml.jackson.datatype.jdk8;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.JavaType;
@@ -10,6 +12,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Java8OptionalUnwrappedTest extends ModuleTestBase
 {
@@ -46,6 +50,7 @@ public class Java8OptionalUnwrappedTest extends ModuleTestBase
 	    public String name;
 	}	
 
+	@Test
 	public void testUntypedWithOptionalsNotNulls() throws Exception
 	{
 		final ObjectMapper mapper = mapperWithModule(false);
@@ -55,6 +60,7 @@ public class Java8OptionalUnwrappedTest extends ModuleTestBase
 	}
 
 	// for [datatype-jdk8#20]
+	@Test
 	public void testShouldSerializeUnwrappedOptional() throws Exception {
          final ObjectMapper mapper = mapperWithModule(false);
 	    
@@ -63,6 +69,7 @@ public class Java8OptionalUnwrappedTest extends ModuleTestBase
 	}
 
 	// for [datatype-jdk8#26]
+	@Test
 	public void testPropogatePrefixToSchema() throws Exception {
         final ObjectMapper mapper = mapperWithModule(false);
 

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/LongStreamSerializerTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/LongStreamSerializerTest.java
@@ -1,11 +1,11 @@
 package com.fasterxml.jackson.datatype.jdk8;
 
-import static org.junit.Assert.*;
-
 import java.io.IOException;
 import java.util.stream.LongStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 @SuppressWarnings({ "unqualified-field-access", "javadoc" })
 public class LongStreamSerializerTest extends StreamTestBase {

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/ModuleTestBase.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/ModuleTestBase.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 
-public abstract class ModuleTestBase extends junit.framework.TestCase
+import static org.junit.jupiter.api.Assertions.fail;
+
+public abstract class ModuleTestBase
 {
     public static class NoCheckSubTypeValidator
         extends PolymorphicTypeValidator.Base

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalBasicTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalBasicTest.java
@@ -2,12 +2,16 @@ package com.fasterxml.jackson.datatype.jdk8;
 
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalBasicTest extends ModuleTestBase
 {
@@ -59,6 +63,7 @@ public class OptionalBasicTest extends ModuleTestBase
 
     private final ObjectMapper MAPPER = mapperWithModule();
 
+	@Test
     public void testOptionalTypeResolution() throws Exception {
 		// With 2.6, we need to recognize it as ReferenceType
 		JavaType t = MAPPER.constructType(Optional.class);
@@ -67,6 +72,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertTrue(t.isReferenceType());
 	}
 
+	@Test
 	public void testDeserAbsent() throws Exception {
 		Optional<?> value = MAPPER.readValue("null",
 				new TypeReference<Optional<String>>() {
@@ -74,6 +80,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertFalse(value.isPresent());
 	}
 
+	@Test
 	public void testDeserSimpleString() throws Exception {
 		Optional<?> value = MAPPER.readValue("\"simpleString\"",
 				new TypeReference<Optional<String>>() {
@@ -82,6 +89,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("simpleString", value.get());
 	}
 
+	@Test
 	public void testDeserInsideObject() throws Exception {
 		OptionalData data = MAPPER.readValue("{\"myString\":\"simpleString\"}",
 				OptionalData.class);
@@ -89,6 +97,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("simpleString", data.myString.get());
 	}
 
+	@Test
 	public void testDeserComplexObject() throws Exception {
 		TypeReference<Optional<OptionalData>> type = new TypeReference<Optional<OptionalData>>() {
 		};
@@ -99,6 +108,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("simpleString", data.get().myString.get());
 	}
 
+	@Test
 	public void testDeserGeneric() throws Exception {
 		TypeReference<Optional<OptionalGenericData<String>>> type = new TypeReference<Optional<OptionalGenericData<String>>>() {
 		};
@@ -109,16 +119,19 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("simpleString", data.get().myData.get());
 	}
 
+	@Test
 	public void testSerAbsent() throws Exception {
 		String value = MAPPER.writeValueAsString(Optional.empty());
 		assertEquals("null", value);
 	}
 
+	@Test
 	public void testSerSimpleString() throws Exception {
 		String value = MAPPER.writeValueAsString(Optional.of("simpleString"));
 		assertEquals("\"simpleString\"", value);
 	}
 
+	@Test
 	public void testSerInsideObject() throws Exception {
 		OptionalData data = new OptionalData();
 		data.myString = Optional.of("simpleString");
@@ -126,6 +139,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("{\"myString\":\"simpleString\"}", value);
 	}
 
+	@Test
 	public void testSerComplexObject() throws Exception {
 		OptionalData data = new OptionalData();
 		data.myString = Optional.of("simpleString");
@@ -133,6 +147,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("{\"myString\":\"simpleString\"}", value);
 	}
 
+	@Test
 	public void testSerGeneric() throws Exception {
 		OptionalGenericData<String> data = new OptionalGenericData<String>();
 		data.myData = Optional.of("simpleString");
@@ -140,6 +155,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("{\"myData\":\"simpleString\"}", value);
 	}
 
+	@Test
 	public void testSerNonNull() throws Exception {
 		OptionalData data = new OptionalData();
 		data.myString = Optional.empty();
@@ -149,6 +165,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("{}", value);
 	}
 
+	@Test
 	public void testSerOptDefault() throws Exception {
 		OptionalData data = new OptionalData();
 		data.myString = Optional.empty();
@@ -157,6 +174,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals("{\"myString\":null}", value);
 	}
 
+	@Test
     public void testSerOptNull() throws Exception {
         OptionalData data = new OptionalData();
         data.myString = null;
@@ -166,6 +184,7 @@ public class OptionalBasicTest extends ModuleTestBase
     }
 
     @SuppressWarnings("deprecation")
+	@Test
     public void testSerOptDisableAsNull() throws Exception {
         final OptionalData data = new OptionalData();
         data.myString = Optional.empty();
@@ -187,6 +206,7 @@ public class OptionalBasicTest extends ModuleTestBase
         assertEquals("{}", mapper.writeValueAsString(data));
     }
 
+	@Test
     public void testSerOptNonEmpty() throws Exception {
         OptionalData data = new OptionalData();
         data.myString = null;
@@ -195,6 +215,7 @@ public class OptionalBasicTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+	@Test
     public void testWithTypingEnabled() throws Exception {
 		final ObjectMapper objectMapper = mapperWithModule();
 		// ENABLE TYPING
@@ -210,6 +231,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertEquals(myData.myString, deserializedMyData.myString);
 	}
 
+	@Test
 	public void testObjectId() throws Exception {
 		final Unit input = new Unit();
 		input.link(input);
@@ -222,6 +244,7 @@ public class OptionalBasicTest extends ModuleTestBase
 		assertSame(result, base);
 	}
 
+	@Test
 	public void testOptionalCollection() throws Exception {
 
 		TypeReference<List<Optional<String>>> typeReference = new TypeReference<List<Optional<String>>>() {
@@ -238,10 +261,11 @@ public class OptionalBasicTest extends ModuleTestBase
 		List<Optional<String>> result = MAPPER.readValue(str, typeReference);
 		assertEquals(list.size(), result.size());
 		for (int i = 0; i < list.size(); ++i) {
-			assertEquals("Entry #" + i, list.get(i), result.get(i));
+			assertEquals(list.get(i), result.get(i), "Entry #" + i);
 		}
 	}
 
+	@Test
 	public void testPolymorphic() throws Exception
 	{
 	    final Container dto = new Container();

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalBooleanTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalBooleanTest.java
@@ -2,7 +2,11 @@ package com.fasterxml.jackson.datatype.jdk8;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalBooleanTest extends ModuleTestBase
 {
@@ -18,6 +22,7 @@ public class OptionalBooleanTest extends ModuleTestBase
     private final ObjectMapper MAPPER = mapperWithModule();
 
     // for [datatype-jdk8#23]
+    @Test
     public void testBoolean() throws Exception
     {
         // First, serialization

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalConverterTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalConverterTest.java
@@ -2,10 +2,14 @@ package com.fasterxml.jackson.datatype.jdk8;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.util.StdConverter;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 // [modules-java#294]: Optional + converters
 public class OptionalConverterTest extends ModuleTestBase
@@ -56,6 +60,7 @@ public class OptionalConverterTest extends ModuleTestBase
     private final ObjectMapper MAPPER = mapperWithModule();
 
     // [modules-java#294]: Optional + converters, deser
+    @Test
     public void testDeserializeOptionalConverting() throws Exception {
         PointReferenceBean w = MAPPER.readerFor(PointReferenceBean.class)
                 .readValue("{\"opt\": [1,2]}");
@@ -68,6 +73,7 @@ public class OptionalConverterTest extends ModuleTestBase
     }
 
     // [modules-java#294]: Optional + converters, ser
+    @Test
     public void testSerializeOptionalConverting() throws Exception {
         assertEquals("{\"opt\":[3,4]}",
                 MAPPER.writeValueAsString(new PointReferenceBean(3, 4)));

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalMergeTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalMergeTest.java
@@ -4,8 +4,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonMerge;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalMergeTest extends ModuleTestBase
 {
@@ -18,6 +22,7 @@ public class OptionalMergeTest extends ModuleTestBase
     private final ObjectMapper MAPPER = mapperWithModule();
 
     // [modules-java8#214]: ReferenceType of List, merge
+    @Test
     public void testMergeToListViaRef() throws Exception
     {
         OptionalListWrapper base = MAPPER.readValue(a2q("{'list':['a']}"),

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalNumbersTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalNumbersTest.java
@@ -4,13 +4,14 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalNumbersTest extends ModuleTestBase
 {
@@ -52,12 +53,14 @@ public class OptionalNumbersTest extends ModuleTestBase
     /**********************************************************
      */
 
+    @Test
     public void testOptionalIntAbsent() throws Exception
     {
         String json = MAPPER.writeValueAsString(OptionalInt.empty());
         assertFalse(MAPPER.readValue(json, OptionalInt.class).isPresent());
     }
 
+    @Test
     public void testOptionalIntInArrayAbsent() throws Exception
     {
         OptionalInt[] ints = MAPPER.readValue("[null]", OptionalInt[].class);
@@ -66,11 +69,13 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertFalse(ints[0].isPresent());
     }
 
+    @Test
     public void testOptionalIntPresent() throws Exception
     {
         assertEquals(5, MAPPER.readValue(MAPPER.writeValueAsBytes(OptionalInt.of(5)), OptionalInt.class).getAsInt());
     }
 
+    @Test
     public void testOptionalIntCoerceFromString() throws Exception
     {
         OptionalInt opt = MAPPER.readValue(q("123"), OptionalInt.class);
@@ -95,11 +100,13 @@ public class OptionalNumbersTest extends ModuleTestBase
     /**********************************************************
      */
 
+    @Test
     public void testOptionalLongAbsent() throws Exception
     {
         assertFalse(MAPPER.readValue(MAPPER.writeValueAsBytes(OptionalLong.empty()), OptionalLong.class).isPresent());
     }
 
+    @Test
     public void testOptionalLongInArrayAbsent() throws Exception
     {
         OptionalLong[] arr = MAPPER.readValue("[null]", OptionalLong[].class);
@@ -107,12 +114,14 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertNotNull(arr[0]);
         assertFalse(arr[0].isPresent());
     }
-    
+
+    @Test
     public void testOptionalLongPresent() throws Exception
     {
         assertEquals(Long.MAX_VALUE, MAPPER.readValue(MAPPER.writeValueAsBytes(OptionalLong.of(Long.MAX_VALUE)), OptionalLong.class).getAsLong());
     }
 
+    @Test
     public void testOptionalLongCoerceFromString() throws Exception
     {
         OptionalLong opt = MAPPER.readValue(q("123"), OptionalLong.class);
@@ -132,7 +141,8 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertNotNull(bean.value);
         assertEquals(19L, bean.value.getAsLong());
     }
-    
+
+    @Test
     public void testOptionalLongSerializeFilter() throws Exception
     {
         ObjectMapper mapper = mapperWithModule()
@@ -158,11 +168,13 @@ public class OptionalNumbersTest extends ModuleTestBase
     /**********************************************************
      */
 
+    @Test
     public void testOptionalDoubleAbsent() throws Exception
     {
         assertFalse(MAPPER.readValue(MAPPER.writeValueAsBytes(OptionalInt.empty()), OptionalInt.class).isPresent());
     }
 
+    @Test
     public void testOptionalDoubleInArrayAbsent() throws Exception
     {
         OptionalDouble[] arr = MAPPER.readValue("[null]", OptionalDouble[].class);
@@ -171,11 +183,13 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertFalse(arr[0].isPresent());
     }
 
+    @Test
     public void testOptionalDoublePresent() throws Exception
     {
         assertEquals(Double.MIN_VALUE, MAPPER.readValue(MAPPER.writeValueAsBytes(OptionalDouble.of(Double.MIN_VALUE)), OptionalDouble.class).getAsDouble());
     }
 
+    @Test
     public void testOptionalDoubleCoerceFromString() throws Exception
     {
         OptionalDouble opt = MAPPER.readValue(q("0.25"), OptionalDouble.class);
@@ -196,6 +210,7 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertEquals(0.5, bean.value.getAsDouble());
     }
 
+    @Test
     public void testOptionalDoubleInArraySpecialValues() throws Exception
     {
         OptionalDouble[] actual = MAPPER.readValue(
@@ -212,6 +227,7 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertArrayEquals(expected, actual);
     }
 
+    @Test
     public void testOptionalDoubleInArraySpecialValuesWithoutCoercion() throws Exception
     {
         OptionalDouble[] actual = MAPPER_WITHOUT_COERCION.readValue(
@@ -227,12 +243,14 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertArrayEquals(expected, actual);
     }
 
+    @Test
     public void testQuotedOptionalDoubleWithoutCoercion()
     {
         assertThrows(MismatchedInputException.class,
                 () -> MAPPER_WITHOUT_COERCION.readValue(a2q("['1']"), OptionalDouble[].class));
     }
 
+    @Test
     public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_null() throws Exception
     {
         OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
@@ -240,6 +258,7 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertEquals(OptionalDouble.empty(), bean.value);
     }
 
+    @Test
     public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_nan() throws Exception
     {
         OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
@@ -247,6 +266,7 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertEquals(OptionalDouble.of(Double.NaN), bean.value);
     }
 
+    @Test
     public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_positiveInfinity() throws Exception
     {
         OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(
@@ -254,6 +274,7 @@ public class OptionalNumbersTest extends ModuleTestBase
         assertEquals(OptionalDouble.of(Double.POSITIVE_INFINITY), bean.value);
     }
 
+    @Test
     public void testOptionalDoubleBeanSpecialValuesWithoutCoercion_negativeInfinity() throws Exception
     {
         OptionalDoubleBean bean = MAPPER_WITHOUT_COERCION.readValue(

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalTest.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -17,6 +19,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalTest extends ModuleTestBase
 {
@@ -126,21 +130,25 @@ public class OptionalTest extends ModuleTestBase
     /**********************************************************
      */
 
+    @Test
     public void testStringAbsent() throws Exception
     {
         assertFalse(roundtrip(Optional.empty(), OPTIONAL_STRING_TYPE).isPresent());
     }
 
+    @Test
     public void testStringPresent() throws Exception
     {
         assertEquals("test", roundtrip(Optional.of("test"), OPTIONAL_STRING_TYPE).get());
     }
 
+    @Test
     public void testBeanAbsent() throws Exception
     {
         assertFalse(roundtrip(Optional.empty(), OPTIONAL_BEAN_TYPE).isPresent());
     }
 
+    @Test
     public void testBeanPresent() throws Exception
     {
         final TestBean bean = new TestBean(Integer.MAX_VALUE, "woopwoopwoopwoopwoop");
@@ -148,6 +156,7 @@ public class OptionalTest extends ModuleTestBase
     }
 
     // [issue#4]
+    @Test
     public void testBeanWithCreator() throws Exception
     {
         final Issue4Entity emptyEntity = new Issue4Entity(Optional.empty());
@@ -160,6 +169,7 @@ public class OptionalTest extends ModuleTestBase
     }
     
     // [issue#4]
+    @Test
     public void testOptionalStringInBean() throws Exception
     {
         OptionalStringBean bean = MAPPER.readValue("{\"value\":\"xyz\"}", OptionalStringBean.class);
@@ -168,6 +178,7 @@ public class OptionalTest extends ModuleTestBase
     }
 
     // To support [datatype-jdk8#8]
+    @Test
     public void testExcludeIfOptionalAbsent() throws Exception
     {
         ObjectMapper mapper = mapperWithModule()
@@ -187,6 +198,7 @@ public class OptionalTest extends ModuleTestBase
                 mapper.writeValueAsString(new OptionalStringBean(null)));
     }
 
+    @Test
     public void testWithCustomDeserializer() throws Exception
     {
         CaseChangingStringWrapper w = MAPPER.readValue(a2q("{'value':'FoobaR'}"),
@@ -195,6 +207,7 @@ public class OptionalTest extends ModuleTestBase
     }
 
     // [modules-java8#36]
+    @Test
     public void testWithCustomDeserializerIfOptionalAbsent() throws Exception
     {
         // 10-Aug-2017, tatu: Actually this is not true: missing value does not trigger
@@ -208,6 +221,7 @@ public class OptionalTest extends ModuleTestBase
                 CaseChangingStringWrapper.class).value);
     }
 
+    @Test
     public void testCustomSerializer() throws Exception
     {
         final String VALUE = "fooBAR";
@@ -215,6 +229,7 @@ public class OptionalTest extends ModuleTestBase
         assertEquals(json, a2q("{'value':'FOOBAR'}"));
     }
 
+    @Test
     public void testCustomSerializerIfOptionalAbsent() throws Exception
     {
         ObjectMapper mapper = mapperWithModule()
@@ -235,6 +250,7 @@ public class OptionalTest extends ModuleTestBase
     }
 
     // [modules-java8#33]: Verify against regression...
+    @Test
     public void testOtherRefSerializers() throws Exception
     {
         String json = MAPPER.writeValueAsString(new AtomicReference<String>("foo"));
@@ -242,6 +258,7 @@ public class OptionalTest extends ModuleTestBase
     }
 
     // Check [databind#2796] here too
+    @Test
     public void testTypeResolution() throws Exception
     {
         // Should be able to construct using parametric `constructType()`

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalWithEmptyTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalWithEmptyTest.java
@@ -2,8 +2,12 @@ package com.fasterxml.jackson.datatype.jdk8;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalWithEmptyTest extends ModuleTestBase
 {
@@ -18,12 +22,14 @@ public class OptionalWithEmptyTest extends ModuleTestBase
         }
     }
 
+    @Test
     public void testOptionalFromEmpty() throws Exception {
         Optional<?> value = MAPPER.readValue(q(""), new TypeReference<Optional<Integer>>() {});
         assertEquals(false, value.isPresent());
     }
 
     // for [datatype-jdk8#23]
+    @Test
     public void testBooleanWithEmpty() throws Exception
     {
         // and looks like a special, somewhat non-conforming case is what a user had

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalnclusionTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/OptionalnclusionTest.java
@@ -4,12 +4,16 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionalnclusionTest extends ModuleTestBase
 {
@@ -55,6 +59,7 @@ public class OptionalnclusionTest extends ModuleTestBase
 
     private final ObjectMapper MAPPER = mapperWithModule();
 
+    @Test
     public void testSerOptNonEmpty() throws Exception
     {
         OptionalData data = new OptionalData();
@@ -64,6 +69,7 @@ public class OptionalnclusionTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testSerOptNonDefault() throws Exception
     {
         OptionalData data = new OptionalData();
@@ -73,6 +79,7 @@ public class OptionalnclusionTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testSerOptNonAbsent() throws Exception
     {
         OptionalData data = new OptionalData();
@@ -82,6 +89,7 @@ public class OptionalnclusionTest extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testExcludeEmptyStringViaOptional() throws Exception
     {
         String json = MAPPER.writeValueAsString(new OptionalNonEmptyStringBean("x"));
@@ -92,6 +100,7 @@ public class OptionalnclusionTest extends ModuleTestBase
         assertEquals("{}", json);
     }
 
+    @Test
     public void testSerPropInclusionAlways() throws Exception
     {
         JsonInclude.Value incl =
@@ -101,6 +110,7 @@ public class OptionalnclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
     }
 
+    @Test
     public void testSerPropInclusionNonNull() throws Exception
     {
         JsonInclude.Value incl =
@@ -110,6 +120,7 @@ public class OptionalnclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
     }
 
+    @Test
     public void testSerPropInclusionNonAbsent() throws Exception
     {
         JsonInclude.Value incl =
@@ -119,6 +130,7 @@ public class OptionalnclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
     }
 
+    @Test
     public void testSerPropInclusionNonEmpty() throws Exception
     {
         JsonInclude.Value incl =
@@ -128,6 +140,7 @@ public class OptionalnclusionTest extends ModuleTestBase
                 mapper.writeValueAsString(OptionalGenericData.construct(Boolean.TRUE)));
     }
 
+    @Test
     public void testMapElementInclusion() throws Exception
     {
         ObjectMapper mapper = mapperWithModule().setDefaultPropertyInclusion(

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/PolymorphicOptionalTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/PolymorphicOptionalTest.java
@@ -2,10 +2,14 @@ package com.fasterxml.jackson.datatype.jdk8;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PolymorphicOptionalTest extends ModuleTestBase
 {
@@ -25,6 +29,7 @@ public class PolymorphicOptionalTest extends ModuleTestBase
     private final ObjectMapper MAPPER = mapperWithModule();
     
     // [datatype-jdk8#14]
+    @Test
     public void testPolymorphic14() throws Exception
     {
         final Container dto = new Container();

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/SchemaVisitorTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/SchemaVisitorTest.java
@@ -3,10 +3,14 @@ package com.fasterxml.jackson.datatype.jdk8;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 // trivial tests visitor used (mostly) for JSON Schema generation
 public class SchemaVisitorTest extends ModuleTestBase
@@ -14,6 +18,7 @@ public class SchemaVisitorTest extends ModuleTestBase
     private final ObjectMapper MAPPER = mapperWithModule();
 
     // for [datatype-jdk8#25]
+    @Test
     public void testOptionalInteger() throws Exception
     {
         final AtomicReference<Object> result = new AtomicReference<>();
@@ -33,6 +38,7 @@ public class SchemaVisitorTest extends ModuleTestBase
     }
 
     // for [datatype-jdk8#25]
+    @Test
     public void testOptionalLong() throws Exception
     {
         final AtomicReference<Object> result = new AtomicReference<>();
@@ -52,6 +58,7 @@ public class SchemaVisitorTest extends ModuleTestBase
     }
     
     // for [datatype-jdk8#25]
+    @Test
     public void testOptionalDouble() throws Exception
     {
         final AtomicReference<Object> result = new AtomicReference<>();

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/StreamSerializerTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/StreamSerializerTest.java
@@ -1,7 +1,5 @@
 package com.fasterxml.jackson.datatype.jdk8;
 
-import static org.junit.Assert.*;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,10 +7,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.datatype.jdk8.OptionalTest.TestBean;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({ "javadoc", "unqualified-field-access" })
 public class StreamSerializerTest extends StreamTestBase {

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestConfigureAbsentsAsNulls.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestConfigureAbsentsAsNulls.java
@@ -5,10 +5,14 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
 public class TestConfigureAbsentsAsNulls extends ModuleTestBase
@@ -39,6 +43,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
     /**********************************************************************
      */
 
+    @Test
     public void testConfigAbsentsAsNullsTrue() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
@@ -48,6 +53,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testConfigAbsentsAsNullsFalse() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(false));
@@ -57,6 +63,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
         assertEquals("{\"myString\":null}", value);
     }
 
+    @Test
     public void testConfigNonAbsentAbsentsAsNullsTrue() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
@@ -66,6 +73,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testConfigNonAbsentAbsentsAsNullsFalse() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(false));
@@ -81,6 +89,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
     /**********************************************************************
      */
 
+    @Test
     public void testOptionalIntAbsentAsNulls() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
@@ -88,6 +97,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testOptionalLongAbsentAsNulls() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
@@ -95,6 +105,7 @@ public class TestConfigureAbsentsAsNulls extends ModuleTestBase
         assertEquals("{}", value);
     }
 
+    @Test
     public void testOptionalDoubleAbsentAsNulls() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalWithPolymorphic.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jdk8/TestOptionalWithPolymorphic.java
@@ -4,12 +4,16 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestOptionalWithPolymorphic extends ModuleTestBase
 {
@@ -69,6 +73,7 @@ public class TestOptionalWithPolymorphic extends ModuleTestBase
 
     final ObjectMapper MAPPER = mapperWithModule();
 
+    @Test
     public void testOptionalMapsFoo() throws Exception {
 
 		Map<String, Object> foo = new LinkedHashMap<>();
@@ -82,6 +87,7 @@ public class TestOptionalWithPolymorphic extends ModuleTestBase
 		_test(MAPPER, foo);
     }
 
+    @Test
     public void testOptionalMapsBar() throws Exception {
 		
 		Map<String, Object> bar = new LinkedHashMap<>();
@@ -95,6 +101,7 @@ public class TestOptionalWithPolymorphic extends ModuleTestBase
 		_test(MAPPER, bar);
     }
 
+    @Test
     public void testOptionalMapsBaz() throws Exception {
 		Map<String, Object> baz = new LinkedHashMap<>();
 		Map<String, Object> loop = new LinkedHashMap<>();
@@ -107,6 +114,7 @@ public class TestOptionalWithPolymorphic extends ModuleTestBase
 		_test(MAPPER, baz);
     }
 
+    @Test
     public void testOptionalWithTypeAnnotation13() throws Exception
     {
         AbstractOptional result = MAPPER.readValue("{\"value\" : 5}",

--- a/datetime/pom.xml
+++ b/datetime/pom.xml
@@ -46,6 +46,13 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
+    <!-- 20-Apr-2024, tatu: JUnit4 no longer from jackson-base, so: -->
+    <!-- TODO, remove this JUnit 4 test dep after JSTEP-10 -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/ConstructorDetectorConfigTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/ConstructorDetectorConfigTest.java
@@ -1,8 +1,8 @@
 package com.fasterxml.jackson.module.paramnames;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/ConstructorDetectorConfigTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/ConstructorDetectorConfigTest.java
@@ -2,10 +2,10 @@ package com.fasterxml.jackson.module.paramnames;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConstructorDetectorConfigTest
     extends ModuleTestBase

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/CreatorWithNamingStrategy74Test.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/CreatorWithNamingStrategy74Test.java
@@ -1,12 +1,12 @@
 package com.fasterxml.jackson.module.paramnames;
 
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.BDDAssertions.then;
 
 import com.fasterxml.jackson.annotation.*;
 
 import com.fasterxml.jackson.databind.*;
-
-import org.junit.Test;
 
 // for [java8-modules#74]
 public class CreatorWithNamingStrategy74Test

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/DelegatingCreatorTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/DelegatingCreatorTest.java
@@ -1,10 +1,10 @@
 package com.fasterxml.jackson.module.paramnames;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.type.*;
 import com.fasterxml.jackson.databind.*;
-
-import org.junit.*;
 
 import java.io.*;
 import java.util.*;

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/EnumNamingTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/EnumNamingTest.java
@@ -1,13 +1,13 @@
 package com.fasterxml.jackson.module.paramnames;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
 
 public class EnumNamingTest extends ModuleTestBase
 {

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/EnumNamingTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/EnumNamingTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EnumNamingTest extends ModuleTestBase
 {

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JDKSerializabilityTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JDKSerializabilityTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JDKSerializabilityTest extends ModuleTestBase
 {

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JDKSerializabilityTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JDKSerializabilityTest.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.paramnames;
 
 import java.io.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.*;
 

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JsonCreatorTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/JsonCreatorTest.java
@@ -1,15 +1,14 @@
 package com.fasterxml.jackson.module.paramnames;
 
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.junit.*;
-
 import static org.assertj.core.api.BDDAssertions.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JsonCreatorTest extends ModuleTestBase
 {

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/MapKeyNames206Test.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/MapKeyNames206Test.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.paramnames;
 
 import java.util.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonKey;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/MapKeyNames206Test.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/MapKeyNames206Test.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 // [modules-java8#206]
 public class MapKeyNames206Test

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/NamingStrategy67Test.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/NamingStrategy67Test.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.module.paramnames;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospectorTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/ParameterNamesAnnotationIntrospectorTest.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.MalformedParametersException;
@@ -19,20 +18,20 @@ import java.lang.reflect.Parameter;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Lovro Pandzic
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ParameterNamesAnnotationIntrospectorTest {
 
-    @Mock
     private ParameterExtractor parameterExtractor;
 
     private ParameterNamesAnnotationIntrospector introspector;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
+        parameterExtractor = Mockito.mock(ParameterExtractor.class);
         introspector = new ParameterNamesAnnotationIntrospector(JsonCreator.Mode.DEFAULT, parameterExtractor);
     }
 
@@ -44,7 +43,7 @@ public class ParameterNamesAnnotationIntrospectorTest {
         Parameter[] givenParameters = givenConstructor.getParameters();
         AnnotatedConstructor owner = new AnnotatedConstructor(null, givenConstructor, null, null);
         AnnotatedParameter annotatedParameter = new AnnotatedParameter(owner, null, null, null, 0);
-        given(parameterExtractor.getParameters(any())).willReturn(givenParameters);
+        when(parameterExtractor.getParameters(any())).thenReturn(givenParameters);
 
         // when
         String actual = introspector.findImplicitPropertyName(annotatedParameter);

--- a/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/PersonTest.java
+++ b/parameter-names/src/test/java/com/fasterxml/jackson/module/paramnames/PersonTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersonTest
 {

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,21 @@
     </dependency>
 
     <!-- 20-Apr-2024, tatu: JUnit4 no longer from jackson-base, so: -->
+    <!-- TODO, remove this JUnit 4 test dep after JSTEP-10 -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
-    <!-- 20-Apr-2024, tatu: JUnit4 no longer from jackson-base, so: -->
-    <!-- TODO, remove this JUnit 4 test dep after JSTEP-10 -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
part of #339 