### PR TITLE
Add feature for time-zone aware lenient date parsing

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeFeature.java
@@ -20,6 +20,19 @@ public enum JavaTimeFeature implements JacksonFeature
     NORMALIZE_DESERIALIZED_ZONE_ID(true),
 
     /**
+     * Feature that determines whether the {@link java.util.TimeZone} of the
+     * {@link com.fasterxml.jackson.databind.DeserializationContext} is used
+     * when leniently deserializing {@link java.time.LocalDate} or
+     * {@link java.time.LocalDateTime} from the UTC/ISO instant format.
+     * <p>
+     * Default setting is disabled, for backwards-compatibility with
+     * Jackson 2.18.
+     *
+     * @since 2.19
+     */
+    USE_TIME_ZONE_FOR_LENIENT_DATE_PARSING(false),
+
+    /**
      * Feature that controls whether stringified numbers (Strings that without
      * quotes would be legal JSON Numbers) may be interpreted as
      * timestamps (enabled) or not (disabled), in case where there is an

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.java
@@ -131,8 +131,8 @@ public final class JavaTimeModule
 
         // // Other deserializers
         desers.addDeserializer(Duration.class, DurationDeserializer.INSTANCE);
-        desers.addDeserializer(LocalDateTime.class, LocalDateTimeDeserializer.INSTANCE);
-        desers.addDeserializer(LocalDate.class, LocalDateDeserializer.INSTANCE);
+        desers.addDeserializer(LocalDateTime.class, LocalDateTimeDeserializer.INSTANCE.withFeatures(_features));
+        desers.addDeserializer(LocalDate.class, LocalDateDeserializer.INSTANCE.withFeatures(_features));
         desers.addDeserializer(LocalTime.class, LocalTimeDeserializer.INSTANCE);
         desers.addDeserializer(MonthDay.class, MonthDayDeserializer.INSTANCE);
         desers.addDeserializer(OffsetTime.class, OffsetTimeDeserializer.INSTANCE);

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -213,3 +213,7 @@ Joey Muia (@jmuia)
  * Reported #337: Negative `Duration` does not round-trip properly with
   `WRITE_DURATIONS_AS_TIMESTAMPS` enabled
   (2.19.0)
+
+Henning Pöttker (@ hpoettker)
+ * Contributed #342: Lenient deserialization of `LocalDate` is not time-zone aware
+  (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,8 @@ Modules:
   `WRITE_DURATIONS_AS_TIMESTAMPS` enabled
  (reported by Joey M)
  (fix by Joo-Hyuk K)
+#342: Lenient deserialization of `LocalDate` is not time-zone aware
+ (contributed by Henning P)
 
 2.18.3 (not yet released)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,8 @@ Modules:
   `WRITE_DURATIONS_AS_TIMESTAMPS` enabled
  (reported by Joey M)
  (fix by Joo-Hyuk K)
-#342: Lenient deserialization of `LocalDate` is not time-zone aware
+#342: Lenient deserialization of `LocalDate`, `LocalDateTime`
+  is not time-zone aware
  (contributed by Henning P)
 
 2.18.3 (not yet released)


### PR DESCRIPTION
Resolves #342

As proposed in the discussion of the issue, the PR adds a value in `JavaTimeFeature` that enables the time-zone to be used when leniently parsing `LocalDate` and `LocalDateTime` from the UTC/ISO instant format.