### PR TITLE
Fix #364: make one-based Month deserializer accept "12"

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OneBasedMonthDeserializer.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/deser/OneBasedMonthDeserializer.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.datatype.jsr310.deser;
 
 import java.io.IOException;
 import java.time.Month;
-import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -17,8 +16,6 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 public class OneBasedMonthDeserializer extends DelegatingDeserializer {
     private static final long serialVersionUID = 1L;
 
-    private static final Pattern HAS_ONE_OR_TWO_DIGITS = Pattern.compile("^\\d{1,2}$");
-
     public OneBasedMonthDeserializer(JsonDeserializer<?> defaultDeserializer) {
         super(defaultDeserializer);
     }
@@ -26,22 +23,44 @@ public class OneBasedMonthDeserializer extends DelegatingDeserializer {
     @Override
     public Object deserialize(JsonParser parser, DeserializationContext context) throws IOException {
         JsonToken token = parser.currentToken();
-        Month zeroBaseMonth = (Month) getDelegatee().deserialize(parser, context);
-        if (!_isNumericValue(parser.getText(), token)) {
-            return zeroBaseMonth;
+        if (_isPossibleNumericValue(token)) {
+            String monthSpec = parser.getText();
+            int oneBasedMonthNumber = _decodeNumber(monthSpec);
+            if (1 <= oneBasedMonthNumber && oneBasedMonthNumber <= 12) {
+                return Month.of(oneBasedMonthNumber);
+            } else if (oneBasedMonthNumber >= 0) {
+                throw new InvalidFormatException(parser, "Month number " + oneBasedMonthNumber + " not allowed for 1-based Month.", oneBasedMonthNumber, Integer.class);
+            }
         }
-        if (zeroBaseMonth == Month.JANUARY) {
-            throw new InvalidFormatException(parser, "Month.JANUARY value not allowed for 1-based Month.", zeroBaseMonth, Month.class);
-        }
-        return zeroBaseMonth.minus(1);
+        return getDelegatee().deserialize(parser, context);
     }
 
-    private boolean _isNumericValue(String text, JsonToken token) {
-        return token == JsonToken.VALUE_NUMBER_INT || _isNumberAsString(text, token);
+    private boolean _isPossibleNumericValue(JsonToken token) {
+        return token == JsonToken.VALUE_NUMBER_INT || token == JsonToken.VALUE_STRING;
     }
 
-    private boolean _isNumberAsString(String text, JsonToken token) {
-        return token == JsonToken.VALUE_STRING && HAS_ONE_OR_TWO_DIGITS.matcher(text).matches();
+    /**
+     * @return Numeric value of input text that represents a 1-digit or 2-digit number.
+     *         Negative value in other cases (empty string, not a number, 3 or more digits).
+     */
+    private int _decodeNumber(String text) {
+        int numValue;
+        switch (text.length()) {
+            case 1:
+                char c = text.charAt(0);
+                boolean cValid = ('0' <= c && c <= '9');
+                numValue = cValid ? (c - '0') : -1;
+                break;
+            case 2:
+                char c1 = text.charAt(0);
+                char c2 = text.charAt(1);
+                boolean c12valid = ('0' <= c1 && c1 <= '9' && '0' <= c2 && c2 <= '9');
+                numValue = c12valid ? (10 * (c1 - '0') + (c2 - '0')) : -1;
+                break;
+            default:
+                numValue = -1;
+        }
+        return numValue;
     }
 
     @Override

--- a/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OneBasedMonthDeserTest.java
+++ b/datetime/src/test/java/com/fasterxml/jackson/datatype/jsr310/deser/OneBasedMonthDeserTest.java
@@ -17,6 +17,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.MockObjectConfiguration;
 import com.fasterxml.jackson.datatype.jsr310.ModuleTestBase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,37 +32,51 @@ public class OneBasedMonthDeserTest extends ModuleTestBase
         public Wrapper() { }
     }
 
-    @Test
-    public void testDeserializationAsString01_oneBased() throws Exception
+    @ParameterizedTest
+    @EnumSource(Month.class)
+    public void testDeserializationAsString01_oneBased(Month expectedMonth) throws Exception
     {
-        assertEquals(Month.JANUARY, readerForOneBased().readValue("\"1\""));
+        int monthNum = expectedMonth.getValue();
+        assertEquals(expectedMonth, readerForOneBased().readValue("\"" + monthNum + '"'));
     }
 
-    @Test
-    public void testDeserializationAsString01_zeroBased() throws Exception
+    @ParameterizedTest
+    @EnumSource(Month.class)
+    public void testDeserializationAsString01_zeroBased(Month expectedMonth) throws Exception
     {
-        assertEquals(Month.FEBRUARY, readerForZeroBased().readValue("\"1\""));
+        int monthNum = expectedMonth.ordinal();
+        assertEquals(expectedMonth, readerForZeroBased().readValue("\"" + monthNum + '"'));
     }
 
 
-    @Test
-    public void testDeserializationAsString02_oneBased() throws Exception
+    @ParameterizedTest
+    @EnumSource(Month.class)
+    public void testDeserializationAsString02_oneBased(Month month) throws Exception
     {
-        assertEquals(Month.JANUARY, readerForOneBased().readValue("\"JANUARY\""));
+        assertEquals(month, readerForOneBased().readValue("\"" + month.name() + '"'));
     }
 
-    @Test
-    public void testDeserializationAsString02_zeroBased() throws Exception
+    @ParameterizedTest
+    @EnumSource(Month.class)
+    public void testDeserializationAsString02_zeroBased(Month month) throws Exception
     {
-        assertEquals(Month.JANUARY, readerForZeroBased().readValue("\"JANUARY\""));
+        assertEquals(month, readerForOneBased().readValue("\"" + month.name() + '"'));
     }
 
-    @Test
-    public void testBadDeserializationAsString01_oneBased() {
+    @ParameterizedTest
+    @CsvSource({
+            "notamonth , 'Cannot deserialize value of type `java.time.Month` from String \"notamonth\": not one of the values accepted for Enum class: [OCTOBER, SEPTEMBER, JUNE, MARCH, MAY, APRIL, JULY, JANUARY, FEBRUARY, DECEMBER, AUGUST, NOVEMBER]'",
+            "JANUAR    , 'Cannot deserialize value of type `java.time.Month` from String \"JANUAR\": not one of the values accepted for Enum class: [OCTOBER, SEPTEMBER, JUNE, MARCH, MAY, APRIL, JULY, JANUARY, FEBRUARY, DECEMBER, AUGUST, NOVEMBER]'",
+            "march     , 'Cannot deserialize value of type `java.time.Month` from String \"march\": not one of the values accepted for Enum class: [OCTOBER, SEPTEMBER, JUNE, MARCH, MAY, APRIL, JULY, JANUARY, FEBRUARY, DECEMBER, AUGUST, NOVEMBER]'",
+            "0         , 'Month number 0 not allowed for 1-based Month.'",
+            "13        , 'Month number 13 not allowed for 1-based Month.'",
+    })
+    public void testBadDeserializationAsString01_oneBased(String monthSpec, String expectedMessage) {
+        String value = "\"" + monthSpec + '"';
         assertError(
-            () -> readerForOneBased().readValue("\"notamonth\""),
+            () -> readerForOneBased().readValue(value),
             InvalidFormatException.class,
-            "Cannot deserialize value of type `java.time.Month` from String \"notamonth\": not one of the values accepted for Enum class: [OCTOBER, SEPTEMBER, JUNE, MARCH, MAY, APRIL, JULY, JANUARY, FEBRUARY, DECEMBER, AUGUST, NOVEMBER]"
+            expectedMessage
         );
     }
 


### PR DESCRIPTION
As described in #364 , `com.fasterxml.jackson.datatype.jsr310.deser.OneBasedMonthDeserializer` incorrectly assumed that all values can be converted to a `Month` value by the original deserializer. This assumptions fails for `"12"`.

In this fix the `OBMD` is refactored in order to depend less on the original deserializer. Certain inputs (1-digit and 2-digit numbers and their string representations) are handled - validated and parsed - directly. Non-numeric inputs as well as numbers that have 3 or more digits are forwarded to the delegate, as before.

Associated tests are expanded to cover all months.