### PR TITLE
Fix a potential problem in `JavaTimeModule._findFactory()`

### DIFF
--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.java
@@ -270,15 +270,23 @@ public final class JavaTimeModule
                     || (method.getParameterCount() != argCount)) {
                 continue;
             }
-            for (int i = 0; i < argCount; ++i) {
-                Class<?> argType = method.getParameter(i).getRawType();
-                if (!argType.isAssignableFrom(argTypes[i])) {
-                    continue;
-                }
+            if (!allArgTypesMatch(argTypes, method)) {
+                continue;
             }
             return method;
         }
         return null;
+    }
+
+    private boolean allArgTypesMatch(Class<?>[] expectedArgTypes, AnnotatedMethod method)
+    {
+        for (int i = 0; i < expectedArgTypes.length; ++i) {
+            Class<?> argType = method.getParameter(i).getRawType();
+            if (!argType.isAssignableFrom(expectedArgTypes[i])) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.java
+++ b/datetime/src/main/java/com/fasterxml/jackson/datatype/jsr310/JavaTimeModule.java
@@ -266,21 +266,19 @@ public final class JavaTimeModule
     {
         final int argCount = argTypes.length;
         for (AnnotatedMethod method : cls.getFactoryMethods()) {
-            if (!name.equals(method.getName())
-                    || (method.getParameterCount() != argCount)) {
-                continue;
+            if (name.equals(method.getName())
+                    && (method.getParameterCount() == argCount)
+                    && _allArgTypesMatch(argTypes, method)) {
+                    return method;
             }
-            if (!allArgTypesMatch(argTypes, method)) {
-                continue;
-            }
-            return method;
         }
         return null;
     }
 
-    private boolean allArgTypesMatch(Class<?>[] expectedArgTypes, AnnotatedMethod method)
+    // @since 2.21
+    private boolean _allArgTypesMatch(Class<?>[] expectedArgTypes, AnnotatedMethod method)
     {
-        for (int i = 0; i < expectedArgTypes.length; ++i) {
+        for (int i = 0, len = expectedArgTypes.length; i < len; ++i) {
             Class<?> argType = method.getParameter(i).getRawType();
             if (!argType.isAssignableFrom(expectedArgTypes[i])) {
                 return false;

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -222,7 +222,7 @@ Joey Muia (@jmuia)
   `WRITE_DURATIONS_AS_TIMESTAMPS` enabled
   (2.19.0)
 
-Henning Pöttker (@ hpoettker)
+Henning Pöttker (@hpoettker)
  * Contributed #342: Lenient deserialization of `LocalDate` is not time-zone aware
   (2.19.0)
 
@@ -230,3 +230,7 @@ Boleslav Bobcik (@bbobcik)
  * Reported, contributed fix for #364: Deserialization of Month in ONE_BASED_MONTHS
    mode fails for value "12"
   (2.19.0)
+
+Albert Lovers (@AlbertLovers)
+ * Reported, contributed fix for #381: Fix a potential problem in `JavaTimeModule._findFactory()`
+  (2.21.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,8 +17,8 @@ Modules:
 #376: Allow specifying custom `DateTimeFormatter` for `OffsetDateTime` ser/deser
   (new constructors?)
  (requested by @ZIRAKrezovic)
-
-No changes since 2.20
+#381: Fix a potential problem in `JavaTimeModule._findFactory()`
+ (reported, fix by, Albert L)
 
 2.20.1 (30-Oct-2025)
 2.20.0 (28-Aug-2025)


### PR DESCRIPTION
Validate the order of the argument types against the order of the parameters. The previous version ignored mismatches and returned the first method with the correct name and correct number of parameters regardless of parameter types.